### PR TITLE
Running locally: automatic sorting of subjects and sessions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-ui
-handler
 workdir
 test
 bids-specification

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 # local env files
 .env.local
 .env.*.local
+.env
 
 # Log files
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ api/*.key
 api/ezbids.key
 api/*.js
 api/*.js.map
+
+handler/__pycache__

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,3 +1,3 @@
 {
-    "**/*.{js,json,ts,vue}": ["npm run style-check", "npm run lint-check"]
+    "**/*.{js,json,ts,vue}": ["prettier --write"]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ COPY . /app
 
 WORKDIR /app
 
-RUN npm install -g npm@9.5.1
+RUN npm install -g npm@9.5.1 pm2 typescript tsc-watch
 
-RUN npm install -g pm2 typescript tsc-watch
-
-RUN npm install
+# build the api and the ui
+RUN cd /app/api && npm install
+RUN cd /app/ui && npm install

--- a/dev.sh
+++ b/dev.sh
@@ -1,37 +1,67 @@
 #!/usr/bin/env bash
 
-set -ex
+# check to see if a .env file exists
+if [ -f .env ]; then
+    echo ".env file exists, loading environment variables from .env file"
+else
+    echo ".env file does not exist, copying example.env to .env"
+    cp example.env .env
+fi
 
-BRAINLIFE_AUTHENTICATION=true
-while getopts "d" flag; do
- case $flag in
-   d)
-     BRAINLIFE_AUTHENTICATION=false
-   ;;
-   \?)
-   ;;
- esac
-done
+# load the environment variables from the .env file
+source .env
 
-export BRAINLIFE_AUTHENTICATION
+echo "Setting Environment Variables from .env file:"
+# display the environment variables read in from .env, could be a gotcha if 
+# the user is unclear about if the .env variables are being used. The .env variables
+# will override environment variables set in the shell as they're set once this script 
+# is run.
+while read line
+do
+  # if line does not start with # then echo the line
+  if [[ $line != \#* ]]; then
+    if [[ $line != "" ]]; then
+      echo "    ${line}"
+    fi
+  fi
+done < .env
 
+if [ $BRAINLIFE_DEVELOPMENT == true ]; then
+  # enable or disable debugging output
+  set -ex
+else
+  set -e
+fi
+
+# Check Node.js version
+REQUIRED_NODE_VERSION="16"
+CURRENT_NODE_VERSION=$(node -v | cut -d '.' -f 1 | sed 's/v//')
+
+if [ "$CURRENT_NODE_VERSION" -ne "$REQUIRED_NODE_VERSION" ]; then
+    echo "Warning: You are using Node.js version $CURRENT_NODE_VERSION. It is recommended to use version $REQUIRED_NODE_VERSION."
+    echo "Please switch to Node.js version $REQUIRED_NODE_VERSION."
+fi
+
+# build local changes and mount them directly into the containers
+# api/ and ui/ are mounted as volumes  at /app within the docker-compose.yml
+(cd api && npm install) || { echo "npm install failed in api"; exit 1; }
+(cd ui && npm install) || { echo "npm install failed in ui"; exit 1; }
+
+# update the bids submodule
 git submodule update --init --recursive
 
-(cd api && npm install)
-(cd ui && npm install)
+DOCKER_COMPOSE_FILE=docker-compose.yml
 
 mkdir -p /tmp/upload
 mkdir -p /tmp/workdir
-
-npm run prepare-husky
 
 ./generate_keys.sh
 
 # ok docker compose is now included in docker as an option for docker
 if [[ $(command -v docker-compose) ]]; then 
     # if the older version is installed use the dash
-    docker-compose --profile development up
+    docker-compose --file ${DOCKER_COMPOSE_FILE} up
 else
     # if the newer version is installed don't use the dash
-    docker compose --profile development up
+    docker compose --file ${DOCKER_COMPOSE_FILE} up
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
-# version: "3"
+networks:
+    ezbids:
 
 services:
     mongodb:
@@ -15,6 +16,8 @@ services:
                 5
         ports:
             - 27417:27017 #for local debugging
+        networks:
+            - ezbids
 
     api:
         container_name: brainlife_ezbids-api
@@ -36,6 +39,8 @@ services:
             BRAINLIFE_AUTHENTICATION: ${BRAINLIFE_AUTHENTICATION}
         ports:
             - 8082:8082 #localhost runs on local browser to it needs to access api via host port
+        networks:
+            - ezbids
 
     handler:
         container_name: brainlife_ezbids-handler
@@ -51,11 +56,16 @@ services:
                 condition: service_healthy
         environment:
             MONGO_CONNECTION_STRING: mongodb://mongodb:27017/ezbids
+            PRESORT: ${PRESORT}
+        networks:
+            - ezbids
         tty: true #turn on color for bids-validator output
         command: pm2 start handler.js --attach --watch --ignore-watch "ui **/node_modules"
 
     ui:
         container_name: brainlife_ezbids-ui
+        env_file:
+            - .env
         build: ./ui
         platform: linux/amd64
         volumes:
@@ -67,7 +77,9 @@ services:
             test: ["CMD", "curl", "-f", "http://localhost:3000"]
         ports:
             - 3000:3000 #vite wants to be exposed on the host for HMR?
-    
+        networks:
+            - ezbids
+
     # by default this is not enabled, need to run docker compose with --profile development to enable this service
     telemetry:
         container_name: brainlife_ezbids-telemetry
@@ -75,6 +87,8 @@ services:
         platform: linux/amd64
         depends_on:
             - mongodb
-        profiles: ["development"]
+        profiles: ["telemetry"]
         ports:
             - 8000:8000 #for local debugging
+        networks:
+            - ezbids

--- a/example.env
+++ b/example.env
@@ -1,0 +1,20 @@
+# Create/Copy this file as .env in the root of the project to set default environment variables
+
+# Set the BRAINLIFE_AUTHENTICATION environment variable to true, if you're not running"
+# this with brainlife don't use."
+BRAINLIFE_AUTHENTICATION=false
+
+# Set the BRAINLIFE_DEVELOPMENT enables additional debugging output and mounts 
+# the ezbids repo/folder into the various containers default is false"
+BRAINLIFE_DEVELOPMENT=false
+
+# Define which profiles to use, e.g. set to COMPOSE_PROFILES=telemetry to enable telemetry 
+COMPOSE_PROFILES=
+
+# Choose whether to pre-sort flat folders full of dicoms, if enabled ezBIDS will attempt
+# to organize a flat folder of dicoms into sub-< indexed subject number > and if applicable
+# ses-< indexed session number> folders.
+PRESORT=true
+
+# Can set a custom workingdir/tmp dir, default is /tmp if it's not set here
+EZBIDS_TMP_DIR=

--- a/handler/Dockerfile
+++ b/handler/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt update && \
     apt-get update && apt-get upgrade -y
 
-RUN apt install -y parallel python3 python3-pip tree curl unzip git jq python libgl-dev python-numpy bc
+RUN apt update && apt install -y parallel python3 python3-pip tree curl unzip git jq python libgl-dev python-numpy bc
 
 RUN pip3 install numpy==1.23.0 nibabel==4.0.0 pandas matplotlib pyyaml==5.4.1 pydicom==2.3.1 natsort pydeface && \
     pip3 install quickshear mne mne-bids
@@ -93,6 +93,9 @@ ENV PATH $NVM_DIR/v$NODE_VERSION/bin:$PATH
 RUN npm install -g npm@9.5.1
 RUN npm install -g bids-validator@1.14.8
 RUN git clone https://github.com/bids-standard/bids-validator
+
+# move copy to last step to save time on container rebuilding
+COPY . /app
 
 # install source code from local
 WORKDIR /app/handler

--- a/handler/bids.sh
+++ b/handler/bids.sh
@@ -39,13 +39,22 @@ echo "Creating ezBIDS telemetry files"
 
 # Telemetry (to hard-coded pet2bids server)
 if [ -f $root/validator.json ]; then
-    curl -H 'Content-Type: application/json' -d @$root/validator.json -X POST http://52.87.154.236/telemetry/
+    curl -H 'Content-Type: application/json' -d @$root/validator.json -X POST $pet2bids_server || {
+        echo "Failed to send validator.json to $pet2bids_server"
+        true
+    }
 fi
 
 if [ -f $root/ezBIDS_core_telemetry.json ]; then
-    curl -H 'Content-Type: application/json' -d @$root/ezBIDS_core_telemetry.json -X POST http://52.87.154.236/telemetry/
+    curl -H 'Content-Type: application/json' -d @$root/ezBIDS_core_telemetry.json -X POST $pet2bids_server || {
+        echo "Failed to send ezBIDS_core_telemetry.json to $pet2bids_server"
+        true
+    }
 fi
 
 if [ -f $root/ezBIDS_finalized_telemetry.json ]; then
-    curl -H 'Content-Type: application/json' -d @$root/ezBIDS_finalized_telemetry.json -X POST http://52.87.154.236/telemetry/
+    curl -H 'Content-Type: application/json' -d @$root/ezBIDS_finalized_telemetry.json -X POST $pet2bids_server || {
+        echo "Failed to send ezBIDS_finalized_telemetry.json to $pet2bids_server"
+        true
+    }
 fi

--- a/handler/convert.js
+++ b/handler/convert.js
@@ -23,6 +23,7 @@ const datasetName = info.datasetDescription.Name;
 
 mkdirp.sync(root + "/bids/" + datasetName);
 fs.writeFileSync(root + "/bids/" + datasetName + "/finalized.json", JSON.stringify(info, null, 4)); //copy the finalized.json
+fs.writeFileSync(root + "/bids/" + datasetName + "/ezBIDS_template.json", JSON.stringify(info, null, 4)); //copy the finalized.json
 fs.writeFileSync(root + "/bids/" + datasetName + "/dataset_description.json", JSON.stringify(info.datasetDescription, null, 4));
 fs.writeFileSync(root + "/bids/" + datasetName + "/.bidsignore", `
 **/excluded

--- a/handler/convert.js
+++ b/handler/convert.js
@@ -110,6 +110,22 @@ async.forEachOf(info.objects, (o, idx, next_o) => {
         let fullpath = root + "/" + path + "/" + name + "_" + filename;
         if (item.name == "json") {
             //we create sidecar from sidecar object (edited by the user)
+            
+            // Remove acquisition date/time information for privacy
+            if (item.sidecar) {
+                delete item.sidecar.AcquisitionDate;
+                delete item.sidecar.AcquisitionDateTime;
+                
+                // Optionally keep just the time if needed
+                if (item.sidecar.AcquisitionTime) {
+                    // Keep AcquisitionTime as it might be needed for analysis
+                    // but ensure no date information is embedded in it
+                    if (item.sidecar.AcquisitionTime.includes('T')) {
+                        item.sidecar.AcquisitionTime = item.sidecar.AcquisitionTime.split('T')[1];
+                    }
+                }
+            }
+            
             item.content = JSON.stringify(item.sidecar, null, 4);
         }
         if (item.content) {

--- a/handler/convert.ts
+++ b/handler/convert.ts
@@ -3,36 +3,43 @@
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const async = require('async');
-const bidsEntitiesOrdered = require('../ui/src/assets/schema/rules/entities.json')
+const bidsEntitiesOrdered = require('../ui/src/assets/schema/rules/entities.json');
 
 //import { IObject, Subject, Session, OrganizedSession } from '../ui/src/store'
 
 const root = process.argv[2];
-if(!root) throw "please specify root directory";
+if (!root) throw 'please specify root directory';
 
-const info = JSON.parse(fs.readFileSync(root+"/finalized.json"));
+const info = JSON.parse(fs.readFileSync(root + '/finalized.json'));
 
 //order the entityMappings correctly, as specified by the BIDS specification
 let newEntityOrdering = {};
-Object.values(bidsEntitiesOrdered).forEach(order=>{
-    Object.keys(info.entityMappings).forEach(key=>{
-        if(order == key) {
-            newEntityOrdering[key] = info.entityMappings[key]
+Object.values(bidsEntitiesOrdered).forEach((order) => {
+    Object.keys(info.entityMappings).forEach((key) => {
+        if (order == key) {
+            newEntityOrdering[key] = info.entityMappings[key];
         }
-    })
-})
-info.entityMappings = newEntityOrdering
+    });
+});
+info.entityMappings = newEntityOrdering;
 
 const datasetName = info.datasetDescription.Name;
 
-mkdirp.sync(root+"/bids/"+datasetName);
-fs.writeFileSync(root+"/bids/"+datasetName+"/finalized.json", JSON.stringify(info, null, 4)); //copy the finalized.json
-fs.writeFileSync(root+"/bids/"+datasetName+"/dataset_description.json", JSON.stringify(info.datasetDescription, null, 4));
-fs.writeFileSync(root+"/bids/"+datasetName+"/.bidsignore", `
+mkdirp.sync(root + '/bids/' + datasetName);
+fs.writeFileSync(root + '/bids/' + datasetName + '/finalized.json', JSON.stringify(info, null, 4)); //copy the finalized.json
+fs.writeFileSync(root + '/bids/' + datasetName + '/ezBIDS_template.json', JSON.stringify(info, null, 4)); //copy the finalized.json
+fs.writeFileSync(
+    root + '/bids/' + datasetName + '/dataset_description.json',
+    JSON.stringify(info.datasetDescription, null, 4)
+);
+fs.writeFileSync(
+    root + '/bids/' + datasetName + '/.bidsignore',
+    `
 **/excluded
 **/*_MP2RAGE.*
 *finalized.json
-`);
+`
+);
 
 info.readme += `
 
@@ -41,94 +48,96 @@ info.readme += `
 This dataset was converted from DICOM to BIDS using ezBIDS (https://brainlife.io/ezbids)
 
 `;
-fs.writeFileSync(root+"/bids/"+datasetName+"/README", info.readme);
-fs.writeFileSync(root+"/bids/"+datasetName+"/participants.json", JSON.stringify(info.participantsColumn, null, 4));
+fs.writeFileSync(root + '/bids/' + datasetName + '/README', info.readme);
+fs.writeFileSync(
+    root + '/bids/' + datasetName + '/participants.json',
+    JSON.stringify(info.participantsColumn, null, 4)
+);
 
 //convert participants.json to tsv
-console.log("outputting participants.json/tsv");
-let keys = ["participant_id"];
-for(let key in info.participantsColumn) {
+console.log('outputting participants.json/tsv');
+let keys = ['participant_id'];
+for (let key in info.participantsColumn) {
     keys.push(key);
 }
 let tsv = [];
 let tsvheader = [];
-for(let key of keys) {
+for (let key of keys) {
     tsvheader.push(key);
 }
 tsv.push(tsvheader);
 
-for(const subject_idx in info.participantInfo) {
+for (const subject_idx in info.participantInfo) {
     const sub = info.subjects[subject_idx];
     let tsvrec = [];
-    tsvrec.push("sub-"+sub.subject);
-    for(let key in info.participantsColumn) {
-        tsvrec.push(info.participantInfo[subject_idx][key]||'n/a');
+    tsvrec.push('sub-' + sub.subject);
+    for (let key in info.participantsColumn) {
+        tsvrec.push(info.participantInfo[subject_idx][key] || 'n/a');
     }
     tsv.push(tsvrec);
 }
 
-let tsvf = fs.openSync(root+"/bids/"+datasetName+"/participants.tsv", "w");
-for(let rec of tsv) {
-    fs.writeSync(tsvf, rec.join("\t")+"\n");
+let tsvf = fs.openSync(root + '/bids/' + datasetName + '/participants.tsv', 'w');
+for (let rec of tsv) {
+    fs.writeSync(tsvf, rec.join('\t') + '\n');
 }
 fs.closeSync(tsvf);
 
 //handle each objects
-async.forEachOf(info.objects, (o, idx, next_o)=>{
-
-    if(o._type == "exclude" || o._exclude) {
-        o._type = "excluded/obj"+o.idx;
+async.forEachOf(info.objects, (o, idx, next_o) => {
+    if (o._type == 'exclude' || o._exclude) {
+        o._type = 'excluded/obj' + o.idx;
         o._entities.description = o._SeriesDescription.replace(/[^0-9a-z]/gi, ''); //inject series desc to filename, remove non-alphanum chars
     }
 
-    let typeTokens = o._type.split("/");
+    let typeTokens = o._type.split('/');
     let modality = typeTokens[0]; //func, dwi, anat, etc.. (or exclude)
     let suffix = typeTokens[1]; //t1w, bold, or "objN" for exclude)
 
     //construct basename
     let tokens = [];
     //for(let k in o._entities) {
-    for(let k in info.entityMappings) {
+    for (let k in info.entityMappings) {
         const sk = info.entityMappings[k];
-        if(o._entities[k]) {
-            tokens.push(sk+"-"+o._entities[k]);
+        if (o._entities[k]) {
+            tokens.push(sk + '-' + o._entities[k]);
         }
     }
 
-    if(o._exclude) {
+    if (o._exclude) {
         //excluded object doesn't have to be validated, so some of the item might collide..
         //let's prevent it by setting some artificial tag
-        tokens.push("ezbids-"+idx);
+        tokens.push('ezbids-' + idx);
     }
 
-    const name = tokens.join("_");
+    const name = tokens.join('_');
 
     function composePath(derivatives) {
-        let path = "bids/"+datasetName;
-        if(derivatives) path += "/derivatives/"+derivatives;
-        path += "/sub-"+o._entities.subject;
-        if(o._entities.session) path += "/ses-"+o._entities.session;
-        path += "/"+modality;
+        let path = 'bids/' + datasetName;
+        if (derivatives) path += '/derivatives/' + derivatives;
+        path += '/sub-' + o._entities.subject;
+        if (o._entities.session) path += '/ses-' + o._entities.session;
+        path += '/' + modality;
 
         return path;
     }
 
     function handleItem(item, filename, derivatives = null) {
         const path = composePath(derivatives);
-        mkdirp.sync(root+"/"+path);
+        mkdirp.sync(root + '/' + path);
 
         //setup directory
-        let fullpath = root+"/"+path+"/"+name+"_"+filename;
+        let fullpath = root + '/' + path + '/' + name + '_' + filename;
 
-        if(item.name == "json") {
+        if (item.name == 'json') {
             //we create sidecar from sidecar object (edited by the user)
             item.content = JSON.stringify(item.sidecar, null, 4);
         }
 
-        if(item.content) {
+        if (item.content) {
             //if item has content to write, then use it instead of normal file
             fs.writeFileSync(fullpath, item.content);
-        } else{
+        } else {
             //otherwise, assume to be normal files (link from the source)
             try {
                 fs.lstatSync(fullpath);
@@ -140,35 +149,35 @@ async.forEachOf(info.objects, (o, idx, next_o)=>{
             //I need to use hardlink so that when archiver tries to create .zip in download API
             //the files will be found. As far as I know, archiver module can't de-reference
             //symlinks
-            fs.linkSync(root+"/"+item.path, fullpath);
+            fs.linkSync(root + '/' + item.path, fullpath);
         }
     }
     function handlePET() {
-        o.items.forEach(item => {
+        o.items.forEach((item) => {
             let derivatives = null;
             switch (item.name) {
-                case "nii.gz":
-                    handleItem(item, suffix + ".nii.gz", derivatives);
+                case 'nii.gz':
+                    handleItem(item, suffix + '.nii.gz', derivatives);
                     break;
-                case "json":
-                    handleItem(item, suffix + ".json", derivatives);
+                case 'json':
+                    handleItem(item, suffix + '.json', derivatives);
                     break;
-                case "tsv":
-                    handleItem(item, suffix + ".tsv", derivatives);
+                case 'tsv':
+                    handleItem(item, suffix + '.tsv', derivatives);
                     break;
                 default:
-                    console.error("unknown PET item name", item.name);
+                    console.error('unknown PET item name', item.name);
             }
         });
     }
     function handlePerf() {
-        o.items.forEach(item => {
+        o.items.forEach((item) => {
             let derivatives = null;
             switch (item.name) {
-                case "nii.gz":
-                    handleItem(item, suffix + ".nii.gz", derivatives);
+                case 'nii.gz':
+                    handleItem(item, suffix + '.nii.gz', derivatives);
                     break;
-                case "json":
+                case 'json':
                     //handle IntendedFor
                     if (o.IntendedFor) {
                         item.sidecar.IntendedFor = [];
@@ -180,31 +189,29 @@ async.forEachOf(info.objects, (o, idx, next_o)=>{
                                 continue;
                             }
                             //if intended object is excluded, skip it
-                            if (io._type == "exclude") continue;
+                            if (io._type == 'exclude') continue;
 
-                            const iomodality = io._type.split("/")[0];
-                            const suffix = io._type.split("/")[1];
+                            const iomodality = io._type.split('/')[0];
+                            const suffix = io._type.split('/')[1];
                             //construct a path relative to the subject
-                            let path = "";
-                            if (io._entities.session)
-                                path += "ses-" + io._entities.session + "/";
-                            path += iomodality + "/";
+                            let path = '';
+                            if (io._entities.session) path += 'ses-' + io._entities.session + '/';
+                            path += iomodality + '/';
                             let tokens = [];
                             //for(let k in io._entities) {
                             for (let k in info.entityMappings) {
                                 const sk = info.entityMappings[k];
-                                if (io._entities[k])
-                                    tokens.push(sk + "-" + io._entities[k]);
+                                if (io._entities[k]) tokens.push(sk + '-' + io._entities[k]);
                             }
-                            path += tokens.join("_");
-                            path += "_" + suffix + ".nii.gz"; //TODO - not sure if this is robust enough..
+                            path += tokens.join('_');
+                            path += '_' + suffix + '.nii.gz'; //TODO - not sure if this is robust enough..
                             item.sidecar.IntendedFor.push(path);
                         }
-                    }                    
-                    handleItem(item, suffix + ".json", derivatives);
+                    }
+                    handleItem(item, suffix + '.json', derivatives);
                     break;
                 default:
-                    console.error("unknown Perfusion item name", item.name);
+                    console.error('unknown Perfusion item name', item.name);
             }
         });
     }
@@ -228,43 +235,43 @@ async.forEachOf(info.objects, (o, idx, next_o)=>{
         */
 
         //find manufacturer (used by UNIT1 derivatives)
-        let manufacturer = "UnknownManufacturer";
-        o.items.forEach(item=>{
-            if(item.sidecar && item.sidecar.Manufacturer) manufacturer = item.sidecar.Manufacturer;
+        let manufacturer = 'UnknownManufacturer';
+        o.items.forEach((item) => {
+            if (item.sidecar && item.sidecar.Manufacturer) manufacturer = item.sidecar.Manufacturer;
         });
 
-        o.items.forEach(item=>{
+        o.items.forEach((item) => {
             let derivatives = null;
-            if(suffix == "UNIT1") derivatives = manufacturer;
+            if (suffix == 'UNIT1') derivatives = manufacturer;
 
-            switch(item.name) {
-            case "nii.gz":
-                if(o.defaced && o.defaceSelection == "defaced") {
-                    item.path = item.path+".defaced.nii.gz";
-                    console.log("using defaced version of t1w", item.path);
-                }
-                handleItem(item, suffix+".nii.gz", derivatives);
-                break;
-            case "json":
-                //handle B0FieldIdentifier and B0FieldSource if present
-                if(o.B0FieldIdentifier) {
-                    if(o.B0FieldIdentifier.length > 1) {
-                        item.sidecar.B0FieldIdentifier = Object.values(o.B0FieldIdentifier)
-                    }else{
-                        item.sidecar.B0FieldIdentifier = o.B0FieldIdentifier[0]
+            switch (item.name) {
+                case 'nii.gz':
+                    if (o.defaced && o.defaceSelection == 'defaced') {
+                        item.path = item.path + '.defaced.nii.gz';
+                        console.log('using defaced version of t1w', item.path);
                     }
-                }
-                if(o.B0FieldSource) {
-                    if(o.B0FieldSource.length > 1) {
-                        item.sidecar.B0FieldSource = Object.values(o.B0FieldSource)
-                    }else{
-                        item.sidecar.B0FieldSource = o.B0FieldSource[0]
+                    handleItem(item, suffix + '.nii.gz', derivatives);
+                    break;
+                case 'json':
+                    //handle B0FieldIdentifier and B0FieldSource if present
+                    if (o.B0FieldIdentifier) {
+                        if (o.B0FieldIdentifier.length > 1) {
+                            item.sidecar.B0FieldIdentifier = Object.values(o.B0FieldIdentifier);
+                        } else {
+                            item.sidecar.B0FieldIdentifier = o.B0FieldIdentifier[0];
+                        }
                     }
-                }
-                handleItem(item, suffix+".json", derivatives);
-                break;
-            default:
-                console.error("unknown anat item name", item.name);
+                    if (o.B0FieldSource) {
+                        if (o.B0FieldSource.length > 1) {
+                            item.sidecar.B0FieldSource = Object.values(o.B0FieldSource);
+                        } else {
+                            item.sidecar.B0FieldSource = o.B0FieldSource[0];
+                        }
+                    }
+                    handleItem(item, suffix + '.json', derivatives);
+                    break;
+                default:
+                    console.error('unknown anat item name', item.name);
             }
         });
     }
@@ -277,65 +284,64 @@ async.forEachOf(info.objects, (o, idx, next_o)=>{
             - sbref
 
         */
-        if(suffix == "events") {
+        if (suffix == 'events') {
             //we handle events a bit differently.. we need to generate events.tsv from items content
-            const events = o.items.find(o=>!!o.eventsBIDS);
-            const headers = Object.keys(events.eventsBIDS[0]) //take first index value to see which columns user selected
-            events.content = headers.join("\t")+"\n";
-            events.eventsBIDS.forEach(rec=>{
-                if(rec.stim_file) {
-                    if(!rec.stim_file.startsWith("/stimuli/")) {
-                        rec.stim_file = "/stimuli/" + rec.stim_file
+            const events = o.items.find((o) => !!o.eventsBIDS);
+            const headers = Object.keys(events.eventsBIDS[0]); //take first index value to see which columns user selected
+            events.content = headers.join('\t') + '\n';
+            events.eventsBIDS.forEach((rec) => {
+                if (rec.stim_file) {
+                    if (!rec.stim_file.startsWith('/stimuli/')) {
+                        rec.stim_file = '/stimuli/' + rec.stim_file;
                     }
                 }
                 const row = [];
-                headers.forEach(key=>{
+                headers.forEach((key) => {
                     row.push(rec[key]);
                 });
-                events.content += row.join("\t")+"\n";
+                events.content += row.join('\t') + '\n';
             });
 
             //add stuff to sidecar
-            const sidecar = o.items.find(o=>o.name == "json");
+            const sidecar = o.items.find((o) => o.name == 'json');
             //sidecar.sidecar.TaskName = o._entities.task;
             sidecar.sidecar.trial_type = {
                 LongName: info.events.trialTypes.longName,
                 Description: info.events.trialTypes.desc,
                 Levels: info.events.trialTypes.levels,
-            }
+            };
 
             //now save
-            handleItem(events, "events.tsv");
-            handleItem(sidecar, "events.json");
+            handleItem(events, 'events.tsv');
+            handleItem(sidecar, 'events.json');
         } else {
-
             //normal func stuff..
-            o.items.forEach(item=>{
-                switch(item.name) {
-                case "nii.gz":
-                    handleItem(item, suffix+".nii.gz");
-                    break;
-                case "json":
-                    //handle B0FieldIdentifier and B0FieldSource if present
-                    if(o.B0FieldIdentifier.length) {
-                        if(o.B0FieldIdentifier.length > 1) {
-                            item.sidecar.B0FieldIdentifier = Object.values(o.B0FieldIdentifier)
-                        }else{
-                            item.sidecar.B0FieldIdentifier = o.B0FieldIdentifier[0]
+            o.items.forEach((item) => {
+                switch (item.name) {
+                    case 'nii.gz':
+                        handleItem(item, suffix + '.nii.gz');
+                        break;
+                    case 'json':
+                        //handle B0FieldIdentifier and B0FieldSource if present
+                        if (o.B0FieldIdentifier.length) {
+                            if (o.B0FieldIdentifier.length > 1) {
+                                item.sidecar.B0FieldIdentifier = Object.values(o.B0FieldIdentifier);
+                            } else {
+                                item.sidecar.B0FieldIdentifier = o.B0FieldIdentifier[0];
+                            }
                         }
-                    }
-                    if(o.B0FieldSource.length) {
-                        if(o.B0FieldSource.length > 1) {
-                            item.sidecar.B0FieldSource = Object.values(o.B0FieldSource)
-                        }else{
-                            item.sidecar.B0FieldSource = o.B0FieldSource[0]
+                        if (o.B0FieldSource.length) {
+                            if (o.B0FieldSource.length > 1) {
+                                item.sidecar.B0FieldSource = Object.values(o.B0FieldSource);
+                            } else {
+                                item.sidecar.B0FieldSource = o.B0FieldSource[0];
+                            }
                         }
-                    }
-                    item.sidecar.TaskName = o._entities.task;
-                    handleItem(item, suffix+".json");
-                    break;
-                default:
-                    console.error("unknown func item name", item.name);
+                        item.sidecar.TaskName = o._entities.task;
+                        handleItem(item, suffix + '.json');
+                        break;
+                    default:
+                        console.error('unknown func item name', item.name);
                 }
             });
         }
@@ -352,150 +358,150 @@ async.forEachOf(info.objects, (o, idx, next_o)=>{
             - magnitude
             - fieldmap
         */
-        o.items.forEach(item=>{
-            switch(item.name) {
-            case "nii.gz":
-                handleItem(item, suffix+".nii.gz");
-                break;
-            case "json":
-                //handle B0FieldIdentifier and B0FieldSource if present
-                if(o.B0FieldIdentifier.length) {
-                    if(o.B0FieldIdentifier.length > 1) {
-                        item.sidecar.B0FieldIdentifier = Object.values(o.B0FieldIdentifier)
-                    }else{
-                        item.sidecar.B0FieldIdentifier = o.B0FieldIdentifier[0]
-                    }
-                }
-                if(o.B0FieldSource.length) {
-                    if(o.B0FieldSource.length > 1) {
-                        item.sidecar.B0FieldSource = Object.values(o.B0FieldSource)
-                    }else{
-                        item.sidecar.B0FieldSource = o.B0FieldSource[0]
-                    }
-                }
-                //handle IntendedFor
-                if(o.IntendedFor) {
-                    item.sidecar.IntendedFor = [];
-                    for(let idx of o.IntendedFor) {
-                        const io = info.objects[idx];
-
-                        //this should not happen, but ezBIDS_core.json could be corrupted..
-                        if(!io) {
-                            console.error("can't find object with ", idx);
-                            continue;
+        o.items.forEach((item) => {
+            switch (item.name) {
+                case 'nii.gz':
+                    handleItem(item, suffix + '.nii.gz');
+                    break;
+                case 'json':
+                    //handle B0FieldIdentifier and B0FieldSource if present
+                    if (o.B0FieldIdentifier.length) {
+                        if (o.B0FieldIdentifier.length > 1) {
+                            item.sidecar.B0FieldIdentifier = Object.values(o.B0FieldIdentifier);
+                        } else {
+                            item.sidecar.B0FieldIdentifier = o.B0FieldIdentifier[0];
                         }
-
-                        //if intended object is excluded, skip it
-                        if(io._type == "exclude") continue;
-
-                        const iomodality = io._type.split("/")[0];
-                        const suffix = io._type.split("/")[1];
-
-                        //construct a path relative to the subject
-                        let path = "";
-                        if(io._entities.session) path += "ses-"+io._entities.session+"/";
-                        path += iomodality+"/";
-                        let tokens = [];
-                        //for(let k in io._entities) {
-                        for(let k in info.entityMappings) {
-                            const sk = info.entityMappings[k];
-                            if(io._entities[k]) tokens.push(sk+"-"+io._entities[k]);
-                        }
-                        path += tokens.join("_");
-                        path += "_"+suffix+".nii.gz";  //TODO - not sure if this is robust enough..
-
-                        item.sidecar.IntendedFor.push(path);
                     }
-                }
+                    if (o.B0FieldSource.length) {
+                        if (o.B0FieldSource.length > 1) {
+                            item.sidecar.B0FieldSource = Object.values(o.B0FieldSource);
+                        } else {
+                            item.sidecar.B0FieldSource = o.B0FieldSource[0];
+                        }
+                    }
+                    //handle IntendedFor
+                    if (o.IntendedFor) {
+                        item.sidecar.IntendedFor = [];
+                        for (let idx of o.IntendedFor) {
+                            const io = info.objects[idx];
 
-                handleItem(item, suffix+".json");
-                break;
-            default:
-                console.error("unknown fmap item name", item.name);
+                            //this should not happen, but ezBIDS_core.json could be corrupted..
+                            if (!io) {
+                                console.error("can't find object with ", idx);
+                                continue;
+                            }
+
+                            //if intended object is excluded, skip it
+                            if (io._type == 'exclude') continue;
+
+                            const iomodality = io._type.split('/')[0];
+                            const suffix = io._type.split('/')[1];
+
+                            //construct a path relative to the subject
+                            let path = '';
+                            if (io._entities.session) path += 'ses-' + io._entities.session + '/';
+                            path += iomodality + '/';
+                            let tokens = [];
+                            //for(let k in io._entities) {
+                            for (let k in info.entityMappings) {
+                                const sk = info.entityMappings[k];
+                                if (io._entities[k]) tokens.push(sk + '-' + io._entities[k]);
+                            }
+                            path += tokens.join('_');
+                            path += '_' + suffix + '.nii.gz'; //TODO - not sure if this is robust enough..
+
+                            item.sidecar.IntendedFor.push(path);
+                        }
+                    }
+
+                    handleItem(item, suffix + '.json');
+                    break;
+                default:
+                    console.error('unknown fmap item name', item.name);
             }
         });
     }
 
     function handleDwi() {
-        o.items.forEach(item=>{
-            switch(item.name) {
-            case "nii.gz":
-                handleItem(item, "dwi.nii.gz");
-                break;
-            case "bvec":
-                handleItem(item, "dwi.bvec");
-                break;
-            case "bval":
-                handleItem(item, "dwi.bval");
-                break;
-            case "json":
-                //handle B0FieldIdentifier and B0FieldSource if present
-                if(o.B0FieldIdentifier.length) {
-                    if(o.B0FieldIdentifier.length > 1) {
-                        item.sidecar.B0FieldIdentifier = Object.values(o.B0FieldIdentifier)
-                    }else{
-                        item.sidecar.B0FieldIdentifier = o.B0FieldIdentifier[0]
+        o.items.forEach((item) => {
+            switch (item.name) {
+                case 'nii.gz':
+                    handleItem(item, 'dwi.nii.gz');
+                    break;
+                case 'bvec':
+                    handleItem(item, 'dwi.bvec');
+                    break;
+                case 'bval':
+                    handleItem(item, 'dwi.bval');
+                    break;
+                case 'json':
+                    //handle B0FieldIdentifier and B0FieldSource if present
+                    if (o.B0FieldIdentifier.length) {
+                        if (o.B0FieldIdentifier.length > 1) {
+                            item.sidecar.B0FieldIdentifier = Object.values(o.B0FieldIdentifier);
+                        } else {
+                            item.sidecar.B0FieldIdentifier = o.B0FieldIdentifier[0];
+                        }
                     }
-                }
-                if(o.B0FieldSource.length) {
-                    if(o.B0FieldSource.length > 1) {
-                        item.sidecar.B0FieldSource = Object.values(o.B0FieldSource)
-                    }else{
-                        item.sidecar.B0FieldSource = o.B0FieldSource[0]
+                    if (o.B0FieldSource.length) {
+                        if (o.B0FieldSource.length > 1) {
+                            item.sidecar.B0FieldSource = Object.values(o.B0FieldSource);
+                        } else {
+                            item.sidecar.B0FieldSource = o.B0FieldSource[0];
+                        }
                     }
-                }
-                handleItem(item, "dwi.json");
-                break;
-            default:
-                console.error("unknown dwi item name", item.name);
+                    handleItem(item, 'dwi.json');
+                    break;
+                default:
+                    console.error('unknown dwi item name', item.name);
             }
         });
 
-        if(!o.items.find(item=>item.name == "bvec")) {
-            console.log("bvec is missing.. assuming that this is b0, and setup empty bvec/bval");
+        if (!o.items.find((item) => item.name == 'bvec')) {
+            console.log('bvec is missing.. assuming that this is b0, and setup empty bvec/bval');
             const path = composePath(false);
             const zeros = [];
-            for(let j = 0;j < o.analysisResults.NumVolumes; ++j) {
+            for (let j = 0; j < o.analysisResults.NumVolumes; ++j) {
                 zeros.push(0);
             }
-            const bvec = `${zeros.join(" ")}\n${zeros.join(" ")}\n${zeros.join(" ")}\n`;
-            fs.writeFileSync(root+"/"+path+"/"+name+"_dwi.bvec", bvec);
+            const bvec = `${zeros.join(' ')}\n${zeros.join(' ')}\n${zeros.join(' ')}\n`;
+            fs.writeFileSync(root + '/' + path + '/' + name + '_dwi.bvec', bvec);
 
-            const bval = zeros.join(" ")+"\n";
-            fs.writeFileSync(root+"/"+path+"/"+name+"_dwi.bval", bval);
+            const bval = zeros.join(' ') + '\n';
+            fs.writeFileSync(root + '/' + path + '/' + name + '_dwi.bval', bval);
         }
     }
 
     //now handle different modality
-    switch(modality) {
-    case "anat":
-        handleAnat();
-        break;
-    case "func":
-        handleFunc();
-        break;
-    case "fmap":
-        handleFmap();
-        break;
-    case "dwi":
-        handleDwi();
-        break;
-    case "perf":
-        handlePerf();
-        break;
-    case "pet":
-        handlePET();
-        break;        
-    case "excluded":
-        if(!info.includeExcluded) break;
-        o.items.forEach((item, idx)=>{
-            //sub-OpenSciJan22_desc-localizer_obj5-0.json
-            handleItem(item, "excluded."+item.name);
-        });
-        break;
+    switch (modality) {
+        case 'anat':
+            handleAnat();
+            break;
+        case 'func':
+            handleFunc();
+            break;
+        case 'fmap':
+            handleFmap();
+            break;
+        case 'dwi':
+            handleDwi();
+            break;
+        case 'perf':
+            handlePerf();
+            break;
+        case 'pet':
+            handlePET();
+            break;
+        case 'excluded':
+            if (!info.includeExcluded) break;
+            o.items.forEach((item, idx) => {
+                //sub-OpenSciJan22_desc-localizer_obj5-0.json
+                handleItem(item, 'excluded.' + item.name);
+            });
+            break;
 
-    default:
-        console.error("unknown datatype:"+o._type);
+        default:
+            console.error('unknown datatype:' + o._type);
     }
     next_o();
 });

--- a/handler/find_img_data.py
+++ b/handler/find_img_data.py
@@ -4,6 +4,12 @@ import os
 import sys
 from pathlib import Path
 from pydicom import dcmread
+from presort_dicoms import presort
+
+# presort can slow down ezBIDS as it examines every dicom, it's enabled/disabled
+# by setting the PRESORT environment varibable to "true" or ""
+presort_enabled = bool(os.getenv('PRESORT', 'false').lower() == 'true')
+
 # if pet2bids is installed we use it wherever the PET data live
 try:
     # import pypet2bids
@@ -13,6 +19,7 @@ except (ImportError, ModuleNotFoundError):
     pet2bidsInstalled = False
     print('pet2bids is not installed, using dcm2niix on PET directories instead')
     sys.exit(1)
+
 
 
 def find_img_data(dir):
@@ -60,12 +67,29 @@ pet_ecat_files_list = []
 pet_dcm_dirs_list = []
 meg_data_list = []
 
+# Find MRI data
 find_img_data('.')
 
 # PET
 pet_folders = [str(folder) for folder in is_pet.pet_folder(Path(root).resolve(), skim=True, njobs=4)]
 pet_folders = [os.path.relpath(x, root) for x in pet_folders if x != '']
 pet_folders = [os.path.join('.', x) for x in pet_folders]
+
+# Automatic session detection
+if presort_enabled:
+    if len(mri_dcm_dirs_list):
+        # Sorting data into sub/ses if presort is enabled  
+        mri_dcm_main_path = os.path.join(root, mri_dcm_dirs_list[0].split('/')[1])
+        print('Main working dirpath: %s' % mri_dcm_main_path)
+        sorted_mri = presort(mri_dcm_main_path)
+        mri_dcm_dirs_list = sorted(sorted_mri)
+
+    elif len(pet_folders) and len(mri_dcm_dirs_list) == 0:
+        # Sorting PET data into sub/ses if presort is enabled (and there's no MRI data present)
+        pet_dcm_main_path = os.path.join(root, pet_folders[0].split('/')[1])
+        print('Main working dirpath: %s' % pet_dcm_main_path)
+        sorted_pet = presort(pet_dcm_main_path)
+        pet_folders = sorted(sorted_pet)
 
 if pet_folders:
     for pet in pet_folders:
@@ -103,13 +127,17 @@ if len(meg_data_list):
 file = open(f'{root}/dcm2niix.list', 'w')
 if len(mri_dcm_dirs_list):
     for dcm in mri_dcm_dirs_list:
-        file.write(dcm + '\n')
+        dcm_path = os.path.relpath(str(dcm), root)
+        dcm_path = os.path.join('.', dcm_path)
+        file.write(dcm_path + '\n')
 file.close()
 
 if len(pet_dcm_dirs_list):
     file = open(f'{root}/pet2bids_dcm.list', 'w')
     for dcm in pet_dcm_dirs_list:
-        file.write(dcm + '\n')
+        dcm_path = os.path.relpath(str(dcm), root)
+        dcm_path = os.path.join('.', dcm_path)
+        file.write(dcm_path + '\n')
     file.close()
 
 if len(pet_ecat_files_list):

--- a/handler/preprocess.sh
+++ b/handler/preprocess.sh
@@ -134,7 +134,7 @@ else
         path=$1
 
         echo "----------------------- ecatpet2bids: $path ------------------------"
-        timeout 3600 ecatpet2bids $path --convert
+        timeout 3600 dcm2niix4pet --silent --ezbids $path
 
         #all good
         echo $path >> pet2bids.done

--- a/handler/presort_dicoms.py
+++ b/handler/presort_dicoms.py
@@ -1,0 +1,250 @@
+import os
+import time
+import subprocess
+import re
+import contextlib
+import io
+import sys
+from pydicom import dcmread
+from pathlib import Path
+from datetime import datetime
+import shutil
+import argparse
+
+@contextlib.contextmanager
+def nostdout():
+    """Suppress stdout temporarily"""
+    save_stdout = sys.stdout
+    sys.stdout = io.StringIO()
+    yield
+    sys.stdout = save_stdout
+
+def is_potential_dicom(file_path):
+    """
+    Check if a file might be a DICOM based on its name/extension.
+    
+    Args:
+        file_path (Path): Path object to the file
+    
+    Returns:
+        bool: True if the file might be a DICOM
+    """
+    print(file_path)
+    suffix = file_path.suffix
+    
+    # if there are multiple suffixes, join them together
+    if len(file_path.suffixes) > 1:
+        suffix = "".join(file_path.suffixes)
+    
+    return (suffix.lower() in [".dcm", ".ima", ".img", ""] or
+            "mr" in str(file_path.name).lower() or
+            bool(re.search(r"\d", suffix.lower())))
+
+def find_dicom_files(folder_path):
+    """
+    Find all potential DICOM files in a folder.
+    
+    Args:
+        folder_path (str or Path): Path to the folder to search
+    
+    Returns:
+        list: List of Path objects for potential DICOM files
+    """
+    #folder_path = Path(folder_path)
+    #return [f for f in folder_path.iterdir() if f.is_file() and is_potential_dicom(f)]
+    return [Path(os.path.join(root, f)) for root, _, filenames in os.walk(folder_path) for f in filenames if is_potential_dicom(Path(os.path.join(root, f)))]
+
+
+def inspect_dicoms(source_folder):
+    """
+    Inspect DICOM files and create a mapping of files to their subject/session organization.
+    
+    Args:
+        source_folder (str): Path to folder containing DICOM files
+    
+    Returns:
+        dict: Nested dictionary of structure:
+            {
+                'sub-<patient_id>': {
+                    'ses-<date>': [list_of_dicom_paths]
+                }
+            }
+    """
+    source_path = Path(source_folder)
+    organization = {}
+    error_count = 0
+    dicom_files = find_dicom_files(source_folder)
+    for dicom_file in dicom_files:
+        try:
+            with nostdout():
+                ds = dcmread(str(dicom_file), stop_before_pixels=True)
+            
+            # Get patient ID (fall back to patient name if ID not available)
+            patient_id = getattr(ds, 'PatientID', None) or getattr(ds, 'PatientName', 'unknown_patient')
+            patient_id = str(patient_id).replace('^', '_')  # Clean up potential special characters
+            subject_id = f'sub-{patient_id}'
+            
+            # Get study date and convert to ISO format
+            study_date = getattr(ds, 'StudyDate', None)
+            if study_date:
+                try:
+                    date_obj = datetime.strptime(study_date, '%Y%m%d')
+                    iso_date = date_obj.strftime('%Y%m%d')
+                except ValueError:
+                    iso_date = 'unknown_date'
+            else:
+                iso_date = 'unknown_date'
+            session_id = f'ses-{iso_date}'
+            
+            # Build the organization dictionary
+            if subject_id not in organization:
+                organization[subject_id] = {}
+            if session_id not in organization[subject_id]:
+                organization[subject_id][session_id] = {"dicoms": [], "other": []}
+            
+            organization[subject_id][session_id]["dicoms"].append(dicom_file)
+            
+        except Exception as e:
+            print(f"Error inspecting {dicom_file}: {e}")
+            error_count += 1
+    
+    # now we collect the folder paths that contain dicoms and associate those
+    # with subject and session id's
+    for subject_id in organization.keys():
+        for session_id in organization[subject_id].keys():
+            # next we get the common paths
+            common_path = os.path.commonpath(organization[subject_id][session_id].get('dicoms'))
+            non_dicoms = [file for file in Path(common_path).iterdir() if file not in dicom_files]
+            for non_dicom in non_dicoms:
+                if non_dicom.is_file():
+                    organization[subject_id][session_id]["other"].append(non_dicom)
+    
+    return organization, error_count, dicom_files
+
+def copy_organized_dicoms(organization, output_base):
+    """
+    Move DICOM files to their organized locations using generic subject/session IDs.
+    
+    Args:
+        organization (dict): Nested dictionary mapping subjects and sessions to DICOM files
+        output_base (str): Base path where organized files will be stored
+    
+    Returns:
+        tuple: (moved_count, error_count, id_mapping)
+        id_mapping is a dict containing the mapping between original and generic IDs
+    """
+    output_path = Path(output_base)
+    output_path.mkdir(parents=True, exist_ok=True)
+    
+    moved_count = 0
+    error_count = 0
+    
+    # Create mappings for generic IDs
+    id_mapping = {
+        'subjects': {},  # original_id -> generic_id
+        'sessions': {}   # (subject_id, original_session) -> generic_session
+    }
+    
+    # First, create the subject mappings
+    for i, subject_id in enumerate(sorted(organization.keys()), 1):
+        generic_subject = f"sub-{i:03d}"  # Creates sub-001, sub-002, etc.
+        id_mapping['subjects'][subject_id] = generic_subject
+    
+    # Then create session mappings for each subject
+    for subject_id in organization:
+        session_numbers = {}  # Keep track of session numbers per subject
+        for session_id in sorted(organization[subject_id].keys()):
+            if subject_id not in session_numbers:
+                session_numbers[subject_id] = 1
+            generic_session = f"ses-{session_numbers[subject_id]:03d}"  # Creates ses-001, ses-002, etc.
+            id_mapping['sessions'][(subject_id, session_id)] = generic_session
+            session_numbers[subject_id] += 1
+    
+    # Now move the files using the generic IDs
+    copied_files = []
+    new_session_folders = set()
+    for subject_id, sessions in organization.items():
+        generic_subject = id_mapping['subjects'][subject_id]
+        for session_id in sessions.keys():
+            generic_session = id_mapping['sessions'][(subject_id, session_id)]
+            # Create session directory with generic IDs
+            session_dir = output_path / generic_subject / generic_session
+            session_dir.mkdir(parents=True, exist_ok=True)
+            new_session_folders.add(session_dir)
+            
+            
+            # Move DICOM files
+            for dicom_file in organization[subject_id][session_id]['dicoms']:
+                try:
+                    shutil.move(dicom_file, session_dir / dicom_file.name)
+                    moved_count += 1
+                except Exception as e:
+                    print(f"Error moving {dicom_file}: {e}")
+                    error_count += 1
+            
+            # Copy non-dicom files
+            for other in organization[subject_id][session_id]['other']:
+                try:
+                    shutil.copy2(other, session_dir / other.name)
+                    copied_files.append(other)
+                except Exception as e:
+                    print(f"Error reorganizing over non-dicom file {other}")
+                    error_count += 1
+    
+    copied_files = list(set(copied_files))
+    for copy in copied_files:
+        print(f"removing source file {copy}")
+        copy.unlink()
+
+    return moved_count, error_count, id_mapping, list(new_session_folders)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Presort DICOM files')
+    parser.add_argument('--source', type=str, help='Path to source folder', required=True)
+    parser.add_argument('--destination', type=str, help='Path to destination folder, if not provided, will use the source folder', default=None)
+    args = parser.parse_args()
+
+    if args.destination is None:
+        args.destination = args.source
+    return args
+
+def presort(source_folder, output_base=None):
+
+    if output_base is None:
+        output_base = source_folder
+     
+    print(f"\nInspecting DICOM files in {source_folder}")
+    organization, inspect_errors, dicom_files = inspect_dicoms(source_folder)
+    from pprint import pprint
+    pprint(organization)
+    
+    print(f"\nFound:")
+    for subject_id, sessions in organization.items():
+        print(f"  {subject_id}:")
+        for session_id, files in sessions.items():
+            print(f"    {session_id}: {len(files)} files")
+    
+    print(f"\nCopying files to {output_base}")
+    moved, move_errors, id_mapping, new_session_folders = copy_organized_dicoms(organization, output_base)
+    
+    print(f"\nID Mappings:")
+    print("Subjects:")
+    for original, generic in id_mapping['subjects'].items():
+        print(f"  {original} -> {generic}")
+    print("\nSessions:")
+    for (subject, session), generic in id_mapping['sessions'].items():
+        print(f"  {subject}, {session} -> {generic}")
+    
+    print(f"\nOrganization complete:")
+    print(f"Successfully moved: {moved} DICOM files")
+    print(f"Errors during inspection: {inspect_errors}")
+    print(f"Errors during moving: {move_errors}")
+
+    return new_session_folders
+
+if __name__ == "__main__":
+    args = parse_args()
+    source_folder = args.source
+    output_base = args.destination
+    presort(source_folder, output_base)

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,9 +40,8 @@
                 "eslint": "^8.52.0",
                 "eslint-config-prettier": "^9.0.0",
                 "eslint-plugin-prettier": "^5.0.1",
-                "husky": "^8.0.3",
                 "lint-staged": "^15.0.2",
-                "prettier": "^3.0.3",
+                "prettier": "^3.3.3",
                 "tsc-watch": "^6.0.4",
                 "typescript": "^4.7.2"
             }
@@ -96,599 +95,696 @@
                 "openapi-types": ">=7"
             }
         },
-        "node_modules/@aws-crypto/crc32": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-            "optional": true,
-            "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/crc32/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "optional": true
-        },
-        "node_modules/@aws-crypto/ie11-detection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "optional": true
-        },
         "node_modules/@aws-crypto/sha256-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
             "optional": true,
             "dependencies": {
-                "@aws-crypto/ie11-detection": "^3.0.0",
-                "@aws-crypto/sha256-js": "^3.0.0",
-                "@aws-crypto/supports-web-crypto": "^3.0.0",
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "optional": true
-        },
-        "node_modules/@aws-crypto/sha256-js": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
-            "optional": true,
-            "dependencies": {
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "optional": true
-        },
-        "node_modules/@aws-crypto/supports-web-crypto": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "optional": true
-        },
-        "node_modules/@aws-crypto/util": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
-            }
-        },
-        "node_modules/@aws-crypto/util/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "optional": true
-        },
-        "node_modules/@aws-sdk/client-cognito-identity": {
-            "version": "3.397.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.397.0.tgz",
-            "integrity": "sha512-xQqjq7Rlg/10Pf5/u2ikn1UwJVTNPjHOvOo0rqwcAES9w8vGkkqCFYRK+cjpcxXXdTPOtN4KHbA5H31GzFVWPg==",
-            "optional": true,
-            "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.395.0",
-                "@aws-sdk/credential-provider-node": "3.395.0",
-                "@aws-sdk/middleware-host-header": "3.391.0",
-                "@aws-sdk/middleware-logger": "3.391.0",
-                "@aws-sdk/middleware-recursion-detection": "3.391.0",
-                "@aws-sdk/middleware-signing": "3.391.0",
-                "@aws-sdk/middleware-user-agent": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@aws-sdk/util-user-agent-browser": "3.391.0",
-                "@aws-sdk/util-user-agent-node": "3.391.0",
-                "@smithy/config-resolver": "^2.0.3",
-                "@smithy/fetch-http-handler": "^2.0.3",
-                "@smithy/hash-node": "^2.0.3",
-                "@smithy/invalid-dependency": "^2.0.3",
-                "@smithy/middleware-content-length": "^2.0.3",
-                "@smithy/middleware-endpoint": "^2.0.3",
-                "@smithy/middleware-retry": "^2.0.3",
-                "@smithy/middleware-serde": "^2.0.3",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/node-http-handler": "^2.0.3",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/smithy-client": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "@smithy/url-parser": "^2.0.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.0.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.3",
-                "@smithy/util-defaults-mode-node": "^2.0.3",
-                "@smithy/util-retry": "^2.0.0",
                 "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "optional": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "optional": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "optional": true,
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "optional": true,
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.651.1.tgz",
+            "integrity": "sha512-FFTWI8uHXzsorQcAtPcvuXkH29sqFXVZa86UUvIrcd6kudakkUBeYDID2KYQm0FP/9uVH4xBBELHRC8PjEGmLw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.651.1",
+                "@aws-sdk/client-sts": "3.651.1",
+                "@aws-sdk/core": "3.651.1",
+                "@aws-sdk/credential-provider-node": "3.651.1",
+                "@aws-sdk/middleware-host-header": "3.649.0",
+                "@aws-sdk/middleware-logger": "3.649.0",
+                "@aws-sdk/middleware-recursion-detection": "3.649.0",
+                "@aws-sdk/middleware-user-agent": "3.649.0",
+                "@aws-sdk/region-config-resolver": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@aws-sdk/util-user-agent-browser": "3.649.0",
+                "@aws-sdk/util-user-agent-node": "3.649.0",
+                "@smithy/config-resolver": "^3.0.6",
+                "@smithy/core": "^2.4.1",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/hash-node": "^3.0.4",
+                "@smithy/invalid-dependency": "^3.0.4",
+                "@smithy/middleware-content-length": "^3.0.6",
+                "@smithy/middleware-endpoint": "^3.1.1",
+                "@smithy/middleware-retry": "^3.0.16",
+                "@smithy/middleware-serde": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.4",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/url-parser": "^3.0.4",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.16",
+                "@smithy/util-defaults-mode-node": "^3.0.16",
+                "@smithy/util-endpoints": "^2.1.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "@smithy/util-retry": "^3.0.4",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.395.0.tgz",
-            "integrity": "sha512-IEmqpZnflzFk6NTlkRpEXIcU2uBrTYl+pA5z4ZerbKclYWuxJ7MoLtLDNWgIn3mkNxvdroWgaPY1B2dkQlTe4g==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.651.1.tgz",
+            "integrity": "sha512-Fm8PoMgiBKmmKrY6QQUGj/WW6eIiQqC1I0AiVXfO+Sqkmxcg3qex+CZBAYrTuIDnvnc/89f9N4mdL8V9DRn03Q==",
             "optional": true,
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.391.0",
-                "@aws-sdk/middleware-logger": "3.391.0",
-                "@aws-sdk/middleware-recursion-detection": "3.391.0",
-                "@aws-sdk/middleware-user-agent": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@aws-sdk/util-user-agent-browser": "3.391.0",
-                "@aws-sdk/util-user-agent-node": "3.391.0",
-                "@smithy/config-resolver": "^2.0.3",
-                "@smithy/fetch-http-handler": "^2.0.3",
-                "@smithy/hash-node": "^2.0.3",
-                "@smithy/invalid-dependency": "^2.0.3",
-                "@smithy/middleware-content-length": "^2.0.3",
-                "@smithy/middleware-endpoint": "^2.0.3",
-                "@smithy/middleware-retry": "^2.0.3",
-                "@smithy/middleware-serde": "^2.0.3",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/node-http-handler": "^2.0.3",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/smithy-client": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "@smithy/url-parser": "^2.0.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.0.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.3",
-                "@smithy/util-defaults-mode-node": "^2.0.3",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.651.1",
+                "@aws-sdk/middleware-host-header": "3.649.0",
+                "@aws-sdk/middleware-logger": "3.649.0",
+                "@aws-sdk/middleware-recursion-detection": "3.649.0",
+                "@aws-sdk/middleware-user-agent": "3.649.0",
+                "@aws-sdk/region-config-resolver": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@aws-sdk/util-user-agent-browser": "3.649.0",
+                "@aws-sdk/util-user-agent-node": "3.649.0",
+                "@smithy/config-resolver": "^3.0.6",
+                "@smithy/core": "^2.4.1",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/hash-node": "^3.0.4",
+                "@smithy/invalid-dependency": "^3.0.4",
+                "@smithy/middleware-content-length": "^3.0.6",
+                "@smithy/middleware-endpoint": "^3.1.1",
+                "@smithy/middleware-retry": "^3.0.16",
+                "@smithy/middleware-serde": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.4",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/url-parser": "^3.0.4",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.16",
+                "@smithy/util-defaults-mode-node": "^3.0.16",
+                "@smithy/util-endpoints": "^2.1.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "@smithy/util-retry": "^3.0.4",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso-oidc": {
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.651.1.tgz",
+            "integrity": "sha512-PKwAyTJW8pgaPIXm708haIZWBAwNycs25yNcD7OQ3NLcmgGxvrx6bSlhPEGcvwdTYwQMJsdx8ls+khlYbLqTvQ==",
+            "optional": true,
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.651.1",
+                "@aws-sdk/credential-provider-node": "3.651.1",
+                "@aws-sdk/middleware-host-header": "3.649.0",
+                "@aws-sdk/middleware-logger": "3.649.0",
+                "@aws-sdk/middleware-recursion-detection": "3.649.0",
+                "@aws-sdk/middleware-user-agent": "3.649.0",
+                "@aws-sdk/region-config-resolver": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@aws-sdk/util-user-agent-browser": "3.649.0",
+                "@aws-sdk/util-user-agent-node": "3.649.0",
+                "@smithy/config-resolver": "^3.0.6",
+                "@smithy/core": "^2.4.1",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/hash-node": "^3.0.4",
+                "@smithy/invalid-dependency": "^3.0.4",
+                "@smithy/middleware-content-length": "^3.0.6",
+                "@smithy/middleware-endpoint": "^3.1.1",
+                "@smithy/middleware-retry": "^3.0.16",
+                "@smithy/middleware-serde": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.4",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/url-parser": "^3.0.4",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.16",
+                "@smithy/util-defaults-mode-node": "^3.0.16",
+                "@smithy/util-endpoints": "^2.1.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "@smithy/util-retry": "^3.0.4",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.651.1"
             }
         },
         "node_modules/@aws-sdk/client-sts": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.395.0.tgz",
-            "integrity": "sha512-zWxZ+pjeP88uRN4k0Zzid6t/8Yhzg1Cv2LnrYX6kZzbS6AOTDho7fVGZgUl+cme33QZhtE8pXUvwGeJAptbhqg==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.651.1.tgz",
+            "integrity": "sha512-4X2RqLqeDuVLk+Omt4X+h+Fa978Wn+zek/AM4HSPi4C5XzRBEFLRRtOQUvkETvIjbEwTYQhm0LdgzcBH4bUqIg==",
             "optional": true,
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/credential-provider-node": "3.395.0",
-                "@aws-sdk/middleware-host-header": "3.391.0",
-                "@aws-sdk/middleware-logger": "3.391.0",
-                "@aws-sdk/middleware-recursion-detection": "3.391.0",
-                "@aws-sdk/middleware-sdk-sts": "3.391.0",
-                "@aws-sdk/middleware-signing": "3.391.0",
-                "@aws-sdk/middleware-user-agent": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@aws-sdk/util-user-agent-browser": "3.391.0",
-                "@aws-sdk/util-user-agent-node": "3.391.0",
-                "@smithy/config-resolver": "^2.0.3",
-                "@smithy/fetch-http-handler": "^2.0.3",
-                "@smithy/hash-node": "^2.0.3",
-                "@smithy/invalid-dependency": "^2.0.3",
-                "@smithy/middleware-content-length": "^2.0.3",
-                "@smithy/middleware-endpoint": "^2.0.3",
-                "@smithy/middleware-retry": "^2.0.3",
-                "@smithy/middleware-serde": "^2.0.3",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/node-http-handler": "^2.0.3",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/smithy-client": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "@smithy/url-parser": "^2.0.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.0.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.3",
-                "@smithy/util-defaults-mode-node": "^2.0.3",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "fast-xml-parser": "4.2.5",
-                "tslib": "^2.5.0"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.651.1",
+                "@aws-sdk/core": "3.651.1",
+                "@aws-sdk/credential-provider-node": "3.651.1",
+                "@aws-sdk/middleware-host-header": "3.649.0",
+                "@aws-sdk/middleware-logger": "3.649.0",
+                "@aws-sdk/middleware-recursion-detection": "3.649.0",
+                "@aws-sdk/middleware-user-agent": "3.649.0",
+                "@aws-sdk/region-config-resolver": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@aws-sdk/util-user-agent-browser": "3.649.0",
+                "@aws-sdk/util-user-agent-node": "3.649.0",
+                "@smithy/config-resolver": "^3.0.6",
+                "@smithy/core": "^2.4.1",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/hash-node": "^3.0.4",
+                "@smithy/invalid-dependency": "^3.0.4",
+                "@smithy/middleware-content-length": "^3.0.6",
+                "@smithy/middleware-endpoint": "^3.1.1",
+                "@smithy/middleware-retry": "^3.0.16",
+                "@smithy/middleware-serde": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.4",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/url-parser": "^3.0.4",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.16",
+                "@smithy/util-defaults-mode-node": "^3.0.16",
+                "@smithy/util-endpoints": "^2.1.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "@smithy/util-retry": "^3.0.4",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.651.1.tgz",
+            "integrity": "sha512-eqOq3W39K+5QTP5GAXtmP2s9B7hhM2pVz8OPe5tqob8o1xQgkwdgHerf3FoshO9bs0LDxassU/fUSz1wlwqfqg==",
+            "optional": true,
+            "dependencies": {
+                "@smithy/core": "^2.4.1",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/signature-v4": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-            "version": "3.397.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.397.0.tgz",
-            "integrity": "sha512-Iv4V///p/iS5jXv5APFASBOOZ8oF8tC2y4G19PpdRWiZVv2A6fOAcguF0/HYr0CwAlvQT0HJA8+IxpMTu/bIQA==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.651.1.tgz",
+            "integrity": "sha512-tvrLvW+PxeJiw2cOc+LwJ0q86TGbXRul12jGswZWG7N71Ybr1s+e9//VeR8UwlxVCJOnm1FiWiWEd5WQmn25sQ==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/client-cognito-identity": "3.397.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/client-cognito-identity": "3.651.1",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.391.0.tgz",
-            "integrity": "sha512-mAzICedcg4bfL0mM5O6QTd9mQ331NLse1DMr6XL21ZZiLB48ej19L7AGV2xq5QwVbqKU3IVv1myRyhvpDM9jMg==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.649.0.tgz",
+            "integrity": "sha512-tViwzM1dauksA3fdRjsg0T8mcHklDa8EfveyiQKK6pUJopkqV6FQx+X5QNda0t/LrdEVlFZvwHNdXqOEfc83TA==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.649.0.tgz",
+            "integrity": "sha512-ODAJ+AJJq6ozbns6ejGbicpsQ0dyMOpnGlg0J9J0jITQ05DKQZ581hdB8APDOZ9N8FstShP6dLZflSj8jb5fNA==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/util-stream": "^3.1.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.395.0.tgz",
-            "integrity": "sha512-t7cWs+syJsSkj9NGdKyZ1t/+nYQyOec2nPjTtPWwKs8D7rvH3IMIgJwkvAGNzYaiIoIpXXx0wgCqys84TSEIYQ==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.651.1.tgz",
+            "integrity": "sha512-yOzPC3GbwLZ8IYzke4fy70ievmunnBUni/MOXFE8c9kAIV+/RMC7IWx14nAAZm0gAcY+UtCXvBVZprFqmctfzA==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.391.0",
-                "@aws-sdk/credential-provider-process": "3.391.0",
-                "@aws-sdk/credential-provider-sso": "3.395.0",
-                "@aws-sdk/credential-provider-web-identity": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/credential-provider-env": "3.649.0",
+                "@aws-sdk/credential-provider-http": "3.649.0",
+                "@aws-sdk/credential-provider-process": "3.649.0",
+                "@aws-sdk/credential-provider-sso": "3.651.1",
+                "@aws-sdk/credential-provider-web-identity": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/credential-provider-imds": "^3.2.1",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.651.1"
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.395.0.tgz",
-            "integrity": "sha512-qJawWTYf5L7Z1Is0sSJEYc4e96Qd0HWGqluO2h9qoUNrRREZ9RSxsDq+LGxVVAYLupYFcIFtiCnA/MoBBIWhzg==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.651.1.tgz",
+            "integrity": "sha512-QKA74Qs83FTUz3jS39kBuNbLAnm6cgDqomm7XS/BkYgtUq+1lI9WL97astNIuoYvumGIS58kuIa+I3ycOA4wgw==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.391.0",
-                "@aws-sdk/credential-provider-ini": "3.395.0",
-                "@aws-sdk/credential-provider-process": "3.391.0",
-                "@aws-sdk/credential-provider-sso": "3.395.0",
-                "@aws-sdk/credential-provider-web-identity": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/credential-provider-env": "3.649.0",
+                "@aws-sdk/credential-provider-http": "3.649.0",
+                "@aws-sdk/credential-provider-ini": "3.651.1",
+                "@aws-sdk/credential-provider-process": "3.649.0",
+                "@aws-sdk/credential-provider-sso": "3.651.1",
+                "@aws-sdk/credential-provider-web-identity": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/credential-provider-imds": "^3.2.1",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.391.0.tgz",
-            "integrity": "sha512-KMlzPlBI+hBmXDo+EoFZdLgCVRkRa9B9iEE6x0+hQQ6g9bW6HI7cDRVdceR1ZoPasSaNAZ9QOXMTIBxTpn0sPQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.649.0.tgz",
+            "integrity": "sha512-6VYPQpEVpU+6DDS/gLoI40ppuNM5RPIEprK30qZZxnhTr5wyrGOeJ7J7wbbwPOZ5dKwta290BiJDU2ipV8Y9BQ==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.395.0.tgz",
-            "integrity": "sha512-wAoHG9XqO0L8TvJv4cjwN/2XkYskp0cbnupKKTJm+D29MYcctKEtL0aYOHxaNN2ECAYxIFIQDdlo62GKb3nJ5Q==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.651.1.tgz",
+            "integrity": "sha512-7jeU+Jbn65aDaNjkjWDQcXwjNTzpYNKovkSSRmfVpP5WYiKerVS5mrfg3RiBeiArou5igCUtYcOKlRJiGRO47g==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/client-sso": "3.395.0",
-                "@aws-sdk/token-providers": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/client-sso": "3.651.1",
+                "@aws-sdk/token-providers": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.391.0.tgz",
-            "integrity": "sha512-n0vYg82B8bc4rxKltVbVqclev7hx+elyS9pEnZs3YbnbWJq0qqsznXmDfLqd1TcWpa09PGXcah0nsRDolVThsA==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.649.0.tgz",
+            "integrity": "sha512-XVk3WsDa0g3kQFPmnCH/LaCtGY/0R2NDv7gscYZSXiBZcG/fixasglTprgWSp8zcA0t7tEIGu9suyjz8ZwhymQ==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sts": "^3.649.0"
             }
         },
         "node_modules/@aws-sdk/credential-providers": {
-            "version": "3.397.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.397.0.tgz",
-            "integrity": "sha512-X7GCXxr62h8mbnt+gZkk+CrfPPgkW/X7QgPIa7ZRHmQicUX7ZwPn5lVmUHTmHS6x+2F+VBigVPdVQ4QiUgC8bw==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.651.1.tgz",
+            "integrity": "sha512-Jv9WikitkarMbW+SaQETJ4/cNapRrsmS2GzU+axc9szqnY+fO6TFcFRB24AvdqCP1uNNasYsbCl/tryZSN/pNg==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/client-cognito-identity": "3.397.0",
-                "@aws-sdk/client-sso": "3.395.0",
-                "@aws-sdk/client-sts": "3.395.0",
-                "@aws-sdk/credential-provider-cognito-identity": "3.397.0",
-                "@aws-sdk/credential-provider-env": "3.391.0",
-                "@aws-sdk/credential-provider-ini": "3.395.0",
-                "@aws-sdk/credential-provider-node": "3.395.0",
-                "@aws-sdk/credential-provider-process": "3.391.0",
-                "@aws-sdk/credential-provider-sso": "3.395.0",
-                "@aws-sdk/credential-provider-web-identity": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/client-cognito-identity": "3.651.1",
+                "@aws-sdk/client-sso": "3.651.1",
+                "@aws-sdk/client-sts": "3.651.1",
+                "@aws-sdk/credential-provider-cognito-identity": "3.651.1",
+                "@aws-sdk/credential-provider-env": "3.649.0",
+                "@aws-sdk/credential-provider-http": "3.649.0",
+                "@aws-sdk/credential-provider-ini": "3.651.1",
+                "@aws-sdk/credential-provider-node": "3.651.1",
+                "@aws-sdk/credential-provider-process": "3.649.0",
+                "@aws-sdk/credential-provider-sso": "3.651.1",
+                "@aws-sdk/credential-provider-web-identity": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/credential-provider-imds": "^3.2.1",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.391.0.tgz",
-            "integrity": "sha512-+nyNr0rb2ixY7mU48nibr7L7gsw37y4oELhqgnNKhcjZDJ34imBwKIMFa64n21FdftmhcjR8IdSpzXE9xrkJ8g==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
+            "integrity": "sha512-PjAe2FocbicHVgNNwdSZ05upxIO7AgTPFtQLpnIAmoyzMcgv/zNB5fBn3uAnQSAeEPPCD+4SYVEUD1hw1ZBvEg==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.391.0.tgz",
-            "integrity": "sha512-KOwl5zo16b17JDhqILHBStccBQ2w35em7+/6vdkJdUII6OU8aVIFTlIQT9wOUvd4do6biIRBMZG3IK0Rg7mRDQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.649.0.tgz",
+            "integrity": "sha512-qdqRx6q7lYC6KL/NT9x3ShTL0TBuxdkCczGzHzY3AnOoYUjnCDH7Vlq867O6MAvb4EnGNECFzIgtkZkQ4FhY5w==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.391.0.tgz",
-            "integrity": "sha512-hVR3z59G7pX4pjDQs9Ag1tMgbLeGXOzeAAaNP9fEtHSd3KBMAGQgN3K3b9WPjzE2W0EoloHRJMK4qxZErdde2g==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.649.0.tgz",
+            "integrity": "sha512-IPnO4wlmaLRf6IYmJW2i8gJ2+UPXX0hDRv1it7Qf8DpBW+lGyF2rnoN7NrFX0WIxdGOlJF1RcOr/HjXb2QeXfQ==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-sdk-sts": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.391.0.tgz",
-            "integrity": "sha512-6ZXI3Z4QU+TnT5PwKWloGmRHG81tWeI18/zxf9wWzrO2NhYFvITzEJH0vWLLiXdWtn/BYfLULXtDvkTaepbI5A==",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/middleware-signing": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@aws-sdk/middleware-signing": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.391.0.tgz",
-            "integrity": "sha512-2pAJJlZqaHc0d+cz2FTVrQmWi8ygKfqfczHUo/loCtOaMNtWXBHb/JsLEecs6cXdizy6gi3YsLz6VZYwY4Ssxw==",
-            "optional": true,
-            "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/signature-v4": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "@smithy/util-middleware": "^2.0.0",
-                "tslib": "^2.5.0"
-            },
-            "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.391.0.tgz",
-            "integrity": "sha512-LdK9uMNA14zqRw3B79Mhy7GX36qld/GYo93xuu+lr+AQ98leZEdc6GUbrtNDI3fP1Z8TMQcyHUKBml4/B+wXpQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.649.0.tgz",
+            "integrity": "sha512-q6sO10dnCXoxe9thobMJxekhJumzd1j6dxcE1+qJdYKHJr6yYgWbogJqrLCpWd30w0lEvnuAHK8lN2kWLdJxJw==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.649.0.tgz",
+            "integrity": "sha512-xURBvdQXvRvca5Du8IlC5FyCj3pkw8Z75+373J3Wb+vyg8GjD14HfKk1Je1HCCQDyIE9VB/scYDcm9ri0ppePw==",
+            "optional": true,
+            "dependencies": {
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.391.0.tgz",
-            "integrity": "sha512-kgfArsKLDJE71qQjfXiHiM5cZqgDHlMsqEx35+A65GmTWJaS1PGDqu3ZvVVU8E5mxnCCLw7vho21fsjvH6TBpg==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.649.0.tgz",
+            "integrity": "sha512-ZBqr+JuXI9RiN+4DSZykMx5gxpL8Dr3exIfFhxMiwAP3DQojwl0ub8ONjMuAjq9OvmX6n+jHZL6fBnNgnNFC8w==",
             "optional": true,
             "dependencies": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.391.0",
-                "@aws-sdk/middleware-logger": "3.391.0",
-                "@aws-sdk/middleware-recursion-detection": "3.391.0",
-                "@aws-sdk/middleware-user-agent": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@aws-sdk/util-user-agent-browser": "3.391.0",
-                "@aws-sdk/util-user-agent-node": "3.391.0",
-                "@smithy/config-resolver": "^2.0.3",
-                "@smithy/fetch-http-handler": "^2.0.3",
-                "@smithy/hash-node": "^2.0.3",
-                "@smithy/invalid-dependency": "^2.0.3",
-                "@smithy/middleware-content-length": "^2.0.3",
-                "@smithy/middleware-endpoint": "^2.0.3",
-                "@smithy/middleware-retry": "^2.0.3",
-                "@smithy/middleware-serde": "^2.0.3",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/node-http-handler": "^2.0.3",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/smithy-client": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "@smithy/url-parser": "^2.0.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.0.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.3",
-                "@smithy/util-defaults-mode-node": "^2.0.3",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            },
+            "peerDependencies": {
+                "@aws-sdk/client-sso-oidc": "^3.649.0"
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.391.0.tgz",
-            "integrity": "sha512-QpYVFKMOnzHz/JMj/b8wb18qxiT92U/5r5MmtRz2R3LOH6ooTO96k4ozXCrYr0qNed1PAnOj73rPrrH2wnCJKQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.649.0.tgz",
+            "integrity": "sha512-PuPw8RysbhJNlaD2d/PzOTf8sbf4Dsn2b7hwyGh7YVG3S75yTpxSAZxrnhKsz9fStgqFmnw/jUfV/G+uQAeTVw==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.391.0.tgz",
-            "integrity": "sha512-zv4sYDTQhNxyLoekcE02/nk3xvoo6yCHDy1kDJk0MFxOKaqUB+CvZdQBR4YBLSDlD4o4DUBmdYgKT58FfbM8sQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.649.0.tgz",
+            "integrity": "sha512-bZI1Wc3R/KibdDVWFxX/N4AoJFG4VJ92Dp4WYmOrVD6VPkb8jPz7ZeiYc7YwPl8NoDjYyPneBV0lEoK/V8OKAA==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/util-endpoints": "^2.1.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-            "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+            "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.391.0.tgz",
-            "integrity": "sha512-6ipHOB1WdCBNeAMJauN7l2qNE0WLVaTNhkD290/ElXm1FHGTL8yw6lIDIjhIFO1bmbZxDiKApwDiG7ROhaJoxQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.649.0.tgz",
+            "integrity": "sha512-IY43r256LhKAvdEVQO/FPdUyVpcZS5EVxh/WHVdNzuN1bNLoUK2rIzuZqVA0EGguvCxoXVmQv9m50GvG7cGktg==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/types": "^2.2.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/types": "^3.4.0",
                 "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.391.0.tgz",
-            "integrity": "sha512-PVvAK/Lf4BdB1eJIZtyFpGSslGQwKpYt9/hKs5NlR+qxBMXU9T0DnTqH4GiXZaazvXr7OUVWitIF2b7iKBMTow==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.649.0.tgz",
+            "integrity": "sha512-x5DiLpZDG/AJmCIBnE3Xhpwy35QIo3WqNiOpw6ExVs1NydbM/e90zFPSfhME0FM66D/WorigvluBxxwjxDm/GA==",
             "optional": true,
             "dependencies": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             },
             "peerDependencies": {
                 "aws-crt": ">=1.0.0"
@@ -697,15 +793,6 @@
                 "aws-crt": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@aws-sdk/util-utf8-browser": {
-            "version": "3.259.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.3.1"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -848,6 +935,15 @@
             "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
             "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
         },
+        "node_modules/@mongodb-js/saslprep": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+            "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+            "optional": true,
+            "dependencies": {
+                "sparse-bitfield": "^3.0.3"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -904,517 +1000,556 @@
             }
         },
         "node_modules/@smithy/abort-controller": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.5.tgz",
-            "integrity": "sha512-byVZ2KWLMPYAZGKjRpniAzLcygJO4ruClZKdJTuB0eCB76ONFTdptBHlviHpAZXknRz7skYWPfcgO9v30A1SyA==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.4.tgz",
+            "integrity": "sha512-VupaALAQlXViW3/enTf/f5l5JZYSAxoJL7f0nanhNNKnww6DGCg1oYIuNP78KDugnkwthBO6iEcym16HhWV8RQ==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.5.tgz",
-            "integrity": "sha512-n0c2AXz+kjALY2FQr7Zy9zhYigXzboIh1AuUUVCqFBKFtdEvTwnwPXrTDoEehLiRTUHNL+4yzZ3s+D0kKYSLSg==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.8.tgz",
+            "integrity": "sha512-Tv1obAC18XOd2OnDAjSWmmthzx6Pdeh63FbLin8MlPiuJ2ATpKkq0NcNOJFr0dO+JmZXnwu8FQxKJ3TKJ3Hulw==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-config-provider": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.6",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.3.tgz",
+            "integrity": "sha512-4LTusLqFMRVQUfC3RNuTg6IzYTeJNpydRdTKq7J5wdEyIRQSu3rGIa3s80mgG2hhe6WOZl9IqTSo1pgbn6EHhA==",
+            "optional": true,
+            "dependencies": {
+                "@smithy/middleware-endpoint": "^3.1.3",
+                "@smithy/middleware-retry": "^3.0.18",
+                "@smithy/middleware-serde": "^3.0.6",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/smithy-client": "^3.3.2",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.6",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.5.tgz",
-            "integrity": "sha512-KFcf/e0meFkQNyteJ65f1G19sgUEY1e5zL7hyAEUPz2SEfBmC9B37WyRq87G3MEEsvmAWwCRu7nFFYUKtR3svQ==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.3.tgz",
+            "integrity": "sha512-VoxMzSzdvkkjMJNE38yQgx4CfnmT+Z+5EUXkg4x7yag93eQkVQgZvN3XBSHC/ylfBbLbAtdu7flTCChX9I+mVg==",
             "optional": true,
             "dependencies": {
-                "@smithy/node-config-provider": "^2.0.5",
-                "@smithy/property-provider": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "@smithy/url-parser": "^2.0.5",
-                "tslib": "^2.5.0"
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/property-provider": "^3.1.6",
+                "@smithy/types": "^3.4.2",
+                "@smithy/url-parser": "^3.0.6",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
-            }
-        },
-        "node_modules/@smithy/eventstream-codec": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.5.tgz",
-            "integrity": "sha512-iqR6OuOV3zbQK8uVs9o+9AxhVk8kW9NAxA71nugwUB+kTY9C35pUd0A5/m4PRT0Y0oIW7W4kgnSR3fdYXQjECw==",
-            "optional": true,
-            "dependencies": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "tslib": "^2.5.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.5.tgz",
-            "integrity": "sha512-EzFoMowdBNy1VqtvkiXgPFEdosIAt4/4bgZ8uiDiUyfhmNXq/3bV+CagPFFBsgFOR/X2XK4zFZHRsoa7PNHVVg==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.7.tgz",
+            "integrity": "sha512-Ra6IPI1spYLO+t62/3jQbodjOwAbto9wlpJdHZwkycm0Kit+GVpzHW/NMmSgY4rK1bjJ4qLAmCnaBzePO5Nkkg==",
             "optional": true,
             "dependencies": {
-                "@smithy/protocol-http": "^2.0.5",
-                "@smithy/querystring-builder": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-base64": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/querystring-builder": "^3.0.6",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.5.tgz",
-            "integrity": "sha512-mk551hIywBITT+kXruRNXk7f8Fy7DTzBjZJSr/V6nolYKmUHIG3w5QU6nO9qPYEQGKc/yEPtkpdS28ndeG93lA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.6.tgz",
+            "integrity": "sha512-c/FHEdKK/7DU2z6ZE91L36ahyXWayR3B+FzELjnYq7wH5YqIseM24V+pWCS9kFn1Ln8OFGTf+pyYPiHZuX0s/Q==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.5.tgz",
-            "integrity": "sha512-0wEi+JT0hM+UUwrJVYbqjuGFhy5agY/zXyiN7BNAJ1XoCDjU5uaNSj8ekPWsXd/d4yM6NSe8UbPd8cOc1+3oBQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.6.tgz",
+            "integrity": "sha512-czM7Ioq3s8pIXht7oD+vmgy4Wfb4XavU/k/irO8NdXFFOx7YAlsCCcKOh/lJD1mJSYQqiR7NmpZ9JviryD/7AQ==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-            "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+            "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.5.tgz",
-            "integrity": "sha512-E7VwV5H02fgZIUGRli4GevBCAPvkyEI/fgl9SU47nPPi3DAAX3nEtUb8xfGbXjOcJ5BdSUoWWZn42tEd/blOqA==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.8.tgz",
+            "integrity": "sha512-VuyszlSO49WKh3H9/kIO2kf07VUwGV80QRiaDxUfP8P8UKlokz381ETJvwLhwuypBYhLymCYyNhB3fLAGBX2og==",
             "optional": true,
             "dependencies": {
-                "@smithy/protocol-http": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.5.tgz",
-            "integrity": "sha512-tyzDuoNTbsMQCq5Xkc4QOt6e2GACUllQIV8SQ5fc59FtOIV9/vbf58/GxVjZm2o8+MMbdDBANjTDZe/ijZKfyA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.3.tgz",
+            "integrity": "sha512-KeM/OrK8MVFUsoJsmCN0MZMVPjKKLudn13xpgwIMpGTYpA8QZB2Xq5tJ+RE6iu3A6NhOI4VajDTwBsm8pwwrhg==",
             "optional": true,
             "dependencies": {
-                "@smithy/middleware-serde": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "@smithy/url-parser": "^2.0.5",
-                "@smithy/util-middleware": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/middleware-serde": "^3.0.6",
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.7",
+                "@smithy/types": "^3.4.2",
+                "@smithy/url-parser": "^3.0.6",
+                "@smithy/util-middleware": "^3.0.6",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.5.tgz",
-            "integrity": "sha512-ulIfbFyzQTVnJbLjUl1CTSi0etg6tej/ekwaLp0Gn8ybUkDkKYa+uB6CF/m2J5B6meRwyJlsryR+DjaOVyiicg==",
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.18.tgz",
+            "integrity": "sha512-YU1o/vYob6vlqZdd97MN8cSXRToknLXhFBL3r+c9CZcnxkO/rgNZ++CfgX2vsmnEKvlqdi26+SRtSzlVp5z6Mg==",
             "optional": true,
             "dependencies": {
-                "@smithy/protocol-http": "^2.0.5",
-                "@smithy/service-error-classification": "^2.0.0",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-middleware": "^2.0.0",
-                "@smithy/util-retry": "^2.0.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/service-error-classification": "^3.0.6",
+                "@smithy/smithy-client": "^3.3.2",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-middleware": "^3.0.6",
+                "@smithy/util-retry": "^3.0.6",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.5.tgz",
-            "integrity": "sha512-in0AA5sous74dOfTGU9rMJBXJ0bDVNxwdXtEt5lh3FVd2sEyjhI+rqpLLRF1E4ixbw3RSEf80hfRpcPdjg4vvQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.6.tgz",
+            "integrity": "sha512-KKTUSl1MzOM0MAjGbudeaVNtIDo+PpekTBkCNwvfZlKndodrnvRo+00USatiyLOc0ujjO9UydMRu3O9dYML7ag==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
-            "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.6.tgz",
+            "integrity": "sha512-2c0eSYhTQ8xQqHMcRxLMpadFbTXg6Zla5l0mwNftFCZMQmuhI7EbAJMx6R5eqfuV3YbJ3QGyS3d5uSmrHV8Khg==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.5.tgz",
-            "integrity": "sha512-LRtjV9WkhONe2lVy+ipB/l1GX60ybzBmFyeRUoLUXWKdnZ3o81jsnbKzMK8hKq8eFSWPk+Lmyx6ZzCQabGeLxg==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.7.tgz",
+            "integrity": "sha512-g3mfnC3Oo8pOI0dYuPXLtdW1WGVb3bR2tkV21GNkm0ZvQjLTtamXAwCWt/FCb0HGvKt3gHHmF1XerG0ICfalOg==",
             "optional": true,
             "dependencies": {
-                "@smithy/property-provider": "^2.0.5",
-                "@smithy/shared-ini-file-loader": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/property-provider": "^3.1.6",
+                "@smithy/shared-ini-file-loader": "^3.1.7",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.5.tgz",
-            "integrity": "sha512-lZm5DZf4b3V0saUw9WTC4/du887P6cy2fUyQgQQKRRV6OseButyD5yTzeMmXE53CaXJBMBsUvvIQ0hRVxIq56w==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.2.tgz",
+            "integrity": "sha512-42Cy4/oT2O+00aiG1iQ7Kd7rE6q8j7vI0gFfnMlUiATvyo8vefJkhb7O10qZY0jAqo5WZdUzfl9IV6wQ3iMBCg==",
             "optional": true,
             "dependencies": {
-                "@smithy/abort-controller": "^2.0.5",
-                "@smithy/protocol-http": "^2.0.5",
-                "@smithy/querystring-builder": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/abort-controller": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/querystring-builder": "^3.0.6",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.5.tgz",
-            "integrity": "sha512-cAFSUhX6aiHcmpWfrCLKvwBtgN1F6A0N8qY/8yeSi0LRLmhGqsY1/YTxFE185MCVzYbqBGXVr9TBv4RUcIV4rA==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.6.tgz",
+            "integrity": "sha512-NK3y/T7Q/Bw+Z8vsVs9MYIQ5v7gOX7clyrXcwhhIBQhbPgRl6JDrZbusO9qWDhcEus75Tg+VCxtIRfo3H76fpw==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.5.tgz",
-            "integrity": "sha512-d2hhHj34mA2V86doiDfrsy2fNTnUOowGaf9hKb0hIPHqvcnShU4/OSc4Uf1FwHkAdYF3cFXTrj5VGUYbEuvMdw==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.3.tgz",
+            "integrity": "sha512-GcbMmOYpH9iRqtC05RbRnc/0FssxSTHlmaNhYBTgSgNCYpdR3Kt88u5GAZTBmouzv+Zlj/VRv92J9ruuDeJuEw==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.5.tgz",
-            "integrity": "sha512-4DCX9krxLzATj+HdFPC3i8pb7XTAWzzKqSw8aTZMjXjtQY+vhe4azMAqIvbb6g7JKwIkmkRAjK6EXO3YWSnJVQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.6.tgz",
+            "integrity": "sha512-sQe08RunoObe+Usujn9+R2zrLuQERi3CWvRO3BvnoWSYUaIrLKuAIeY7cMeDax6xGyfIP3x/yFWbEKSXvOnvVg==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.5.tgz",
-            "integrity": "sha512-C2stCULH0r54KBksv3AWcN8CLS3u9+WsEW8nBrvctrJ5rQTNa1waHkffpVaiKvcW2nP0aIMBPCobD/kYf/q9mA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.6.tgz",
+            "integrity": "sha512-UJKw4LlEkytzz2Wq+uIdHf6qOtFfee/o7ruH0jF5I6UAuU+19r9QV7nU3P/uI0l6+oElRHmG/5cBBcGJrD7Ozg==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
-            "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.6.tgz",
+            "integrity": "sha512-53SpchU3+DUZrN7J6sBx9tBiCVGzsib2e4sc512Q7K9fpC5zkJKs6Z9s+qbMxSYrkEkle6hnMtrts7XNkMJJMg==",
             "optional": true,
+            "dependencies": {
+                "@smithy/types": "^3.4.2"
+            },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.5.tgz",
-            "integrity": "sha512-Mvtk6FwMtfbKRC4YuSsIqRYp9WTxsSUJVVo2djgyhcacKGMqicHDWSAmgy3sDrKv+G/G6xTZCPwm6pJARtdxVg==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.7.tgz",
+            "integrity": "sha512-IA4K2qTJYXkF5OfVN4vsY1hfnUZjaslEE8Fsr/gGFza4TAC2A9NfnZuSY2srQIbt9bwtjHiAayrRVgKse4Q7fA==",
             "optional": true,
             "dependencies": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.5.tgz",
-            "integrity": "sha512-ABIzXmUDXK4n2c9cXjQLELgH2RdtABpYKT+U131e2I6RbCypFZmxIHmIBufJzU2kdMCQ3+thBGDWorAITFW04A==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.3.tgz",
+            "integrity": "sha512-YD2KYSCEEeFHcWZ1E3mLdAaHl8T/TANh6XwmocQ6nPcTdBfh4N5fusgnblnWDlnlU1/cUqEq3PiGi22GmT2Lkg==",
             "optional": true,
             "dependencies": {
-                "@smithy/eventstream-codec": "^2.0.5",
-                "@smithy/is-array-buffer": "^2.0.0",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.0",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/is-array-buffer": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.6",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.5.tgz",
-            "integrity": "sha512-kCTFr8wfOAWKDzGvfBElc6shHigWtHNhMQ1IbosjC4jOlayFyZMSs2PysKB+Ox/dhQ41KqOzgVjgiQ+PyWqHMQ==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.2.tgz",
+            "integrity": "sha512-RKDfhF2MTwXl7jan5d7QfS9eCC6XJbO3H+EZAvLQN8A5in4ib2Ml4zoeLo57w9QrqFekBPcsoC2hW3Ekw4vQ9Q==",
             "optional": true,
             "dependencies": {
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-stream": "^2.0.5",
-                "tslib": "^2.5.0"
+                "@smithy/middleware-endpoint": "^3.1.3",
+                "@smithy/middleware-stack": "^3.0.6",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-stream": "^3.1.6",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/types": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
-            "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
+            "integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.5.tgz",
-            "integrity": "sha512-OdMBvZhpckQSkugCXNJQCvqJ71wE7Ftxce92UOQLQ9pwF6hoS5PLL7wEfpnuEXtStzBqJYkzu1C1ZfjuFGOXAA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.6.tgz",
+            "integrity": "sha512-47Op/NU8Opt49KyGpHtVdnmmJMsp2hEwBdyjuFB9M2V5QVOwA7pBhhxKN5z6ztKGrMw76gd8MlbPuzzvaAncuQ==",
             "optional": true,
             "dependencies": {
-                "@smithy/querystring-parser": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/querystring-parser": "^3.0.6",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/util-base64": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-            "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
             "optional": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-body-length-browser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-            "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+            "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@smithy/util-body-length-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-            "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+            "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-buffer-from": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-            "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
             "optional": true,
             "dependencies": {
-                "@smithy/is-array-buffer": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-config-provider": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-            "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+            "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.5.tgz",
-            "integrity": "sha512-yciP6TPttLsj731aHTvekgyuCGXQrEAJibEwEWAh3kzaDsfGAVCuZSBlyvC2Dl3TZmHKCOQwHV8mIE7KQCTPuQ==",
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.18.tgz",
+            "integrity": "sha512-/eveCzU6Z6Yw8dlYQLA4rcK30XY0E4L3lD3QFHm59mzDaWYelrXE1rlynuT3J6qxv+5yNy3a1JuzhG5hk5hcmw==",
             "optional": true,
             "dependencies": {
-                "@smithy/property-provider": "^2.0.5",
-                "@smithy/types": "^2.2.2",
+                "@smithy/property-provider": "^3.1.6",
+                "@smithy/smithy-client": "^3.3.2",
+                "@smithy/types": "^3.4.2",
                 "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">= 10.0.0"
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.5.tgz",
-            "integrity": "sha512-M07t99rWasXt+IaDZDyP3BkcoEm/mgIE1RIMASrE49LKSNxaVN7PVcgGc77+4uu2kzBAyqJKy79pgtezuknyjQ==",
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.18.tgz",
+            "integrity": "sha512-9cfzRjArtOFPlTYRREJk00suUxVXTgbrzVncOyMRTUeMKnecG/YentLF3cORa+R6mUOMSrMSnT18jos1PKqK6Q==",
             "optional": true,
             "dependencies": {
-                "@smithy/config-resolver": "^2.0.5",
-                "@smithy/credential-provider-imds": "^2.0.5",
-                "@smithy/node-config-provider": "^2.0.5",
-                "@smithy/property-provider": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/config-resolver": "^3.0.8",
+                "@smithy/credential-provider-imds": "^3.2.3",
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/property-provider": "^3.1.6",
+                "@smithy/smithy-client": "^3.3.2",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
                 "node": ">= 10.0.0"
             }
         },
-        "node_modules/@smithy/util-hex-encoding": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-            "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+        "node_modules/@smithy/util-endpoints": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.2.tgz",
+            "integrity": "sha512-FEISzffb4H8DLzGq1g4MuDpcv6CIG15fXoQzDH9SjpRJv6h7J++1STFWWinilG0tQh9H1v2UKWG19Jjr2B16zQ==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+            "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
-            "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.6.tgz",
+            "integrity": "sha512-BxbX4aBhI1O9p87/xM+zWy0GzT3CEVcXFPBRDoHAM+pV0eSW156pR+PSYEz0DQHDMYDsYAflC2bQNz2uaDBUZQ==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
-            "integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.6.tgz",
+            "integrity": "sha512-BRZiuF7IwDntAbevqMco67an0Sr9oLQJqqRCsSPZZHYRnehS0LHDAkJk/pSmI7Z8c/1Vet294H7fY2fWUgB+Rg==",
             "optional": true,
             "dependencies": {
-                "@smithy/service-error-classification": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/service-error-classification": "^3.0.6",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">= 14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.5.tgz",
-            "integrity": "sha512-ylx27GwI05xLpYQ4hDIfS15vm+wYjNN0Sc2P0FxuzgRe8v0BOLHppGIQ+Bezcynk8C9nUzsUue3TmtRhjut43g==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.6.tgz",
+            "integrity": "sha512-lQEUfTx1ht5CRdvIjdAN/gUL6vQt2wSARGGLaBHNe+iJSkRHlWzY+DOn0mFTmTgyU3jcI5n9DkT5gTzYuSOo6A==",
             "optional": true,
             "dependencies": {
-                "@smithy/fetch-http-handler": "^2.0.5",
-                "@smithy/node-http-handler": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/fetch-http-handler": "^3.2.7",
+                "@smithy/node-http-handler": "^3.2.2",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-uri-escape": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-            "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
             "optional": true,
             "dependencies": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@smithy/util-utf8": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-            "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
             "optional": true,
             "dependencies": {
-                "@smithy/util-buffer-from": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/@types/async": {
@@ -1538,9 +1673,9 @@
             }
         },
         "node_modules/@types/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+            "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
         },
         "node_modules/@types/whatwg-url": {
             "version": "8.2.2",
@@ -1888,24 +2023,24 @@
             }
         },
         "node_modules/ansi-escapes": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-            "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+            "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
             "dev": true,
             "dependencies": {
-                "type-fest": "^1.0.2"
+                "environment": "^1.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
             "dev": true,
             "engines": {
                 "node": ">=12"
@@ -2058,9 +2193,9 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.20.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.5",
@@ -2070,7 +2205,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -2108,12 +2243,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -2206,12 +2341,18 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2244,31 +2385,31 @@
             }
         },
         "node_modules/cli-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dev": true,
             "dependencies": {
-                "restore-cursor": "^4.0.0"
+                "restore-cursor": "^5.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cli-truncate": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-            "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+            "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
             "dev": true,
             "dependencies": {
                 "slice-ansi": "^5.0.0",
-                "string-width": "^5.0.0"
+                "string-width": "^7.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -2436,9 +2577,9 @@
             }
         },
         "node_modules/cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
             "engines": {
                 "node": ">= 0.6"
             }
@@ -2600,6 +2741,22 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/define-lazy-prop": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -2658,12 +2815,6 @@
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
         },
-        "node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true
-        },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2678,15 +2829,15 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
             "dev": true
         },
         "node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -2697,6 +2848,37 @@
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dependencies": {
                 "once": "^1.4.0"
+            }
+        },
+        "node_modules/environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/escape-html": {
@@ -3026,36 +3208,36 @@
             }
         },
         "node_modules/express": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+            "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.1",
+                "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.5.0",
+                "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
+                "finalhandler": "1.3.1",
                 "fresh": "0.5.2",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
+                "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
+                "path-to-regexp": "0.1.10",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "type-is": "~1.6.18",
@@ -3094,43 +3276,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-2.1.3.tgz",
             "integrity": "sha512-wj4tLMyCVYuIIKHGt0FhCtIViBcwzWejX0EjNxveAa6dG+0XBCQhMbx+PnkLkFCxLC69qoFrxds4pIyL88inaQ=="
-        },
-        "node_modules/express/node_modules/body-parser": {
-            "version": "1.20.1",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-            "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-            "dependencies": {
-                "bytes": "3.1.2",
-                "content-type": "~1.0.4",
-                "debug": "2.6.9",
-                "depd": "2.0.0",
-                "destroy": "1.2.0",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "on-finished": "2.4.1",
-                "qs": "6.11.0",
-                "raw-body": "2.5.1",
-                "type-is": "~1.6.18",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8",
-                "npm": "1.2.8000 || >= 1.4.16"
-            }
-        },
-        "node_modules/express/node_modules/raw-body": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-            "dependencies": {
-                "bytes": "3.1.2",
-                "http-errors": "2.0.0",
-                "iconv-lite": "0.4.24",
-                "unpipe": "1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
         },
         "node_modules/express/node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -3204,17 +3349,17 @@
             "dev": true
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
             "funding": [
-                {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
-                },
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
                 }
             ],
             "optional": true,
@@ -3247,9 +3392,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -3259,12 +3404,12 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
             "dependencies": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
@@ -3344,19 +3489,38 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-east-asian-width": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+            "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3"
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -3452,6 +3616,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dependencies": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3463,17 +3638,6 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
-        "node_modules/has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "dependencies": {
-                "function-bind": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3483,10 +3647,21 @@
                 "node": ">=8"
             }
         },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -3503,6 +3678,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/http-errors": {
@@ -3527,21 +3713,6 @@
             "dev": true,
             "engines": {
                 "node": ">=16.17.0"
-            }
-        },
-        "node_modules/husky": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-            "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-            "dev": true,
-            "bin": {
-                "husky": "lib/bin.js"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/typicode"
             }
         },
         "node_modules/iconv-lite": {
@@ -3622,10 +3793,17 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
-        "node_modules/ip": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
@@ -3780,6 +3958,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
         "node_modules/json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3907,30 +4090,33 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+            "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
             }
         },
         "node_modules/lint-staged": {
-            "version": "15.0.2",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.0.2.tgz",
-            "integrity": "sha512-vnEy7pFTHyVuDmCAIFKR5QDO8XLVlPFQQyujQ/STOxe40ICWqJ6knS2wSJ/ffX/Lw0rz83luRDh+ET7toN+rOw==",
+            "version": "15.2.10",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
+            "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
             "dev": true,
             "dependencies": {
-                "chalk": "5.3.0",
-                "commander": "11.1.0",
-                "debug": "4.3.4",
-                "execa": "8.0.1",
-                "lilconfig": "2.1.0",
-                "listr2": "7.0.2",
-                "micromatch": "4.0.5",
-                "pidtree": "0.6.0",
-                "string-argv": "0.3.2",
-                "yaml": "2.3.3"
+                "chalk": "~5.3.0",
+                "commander": "~12.1.0",
+                "debug": "~4.3.6",
+                "execa": "~8.0.1",
+                "lilconfig": "~3.1.2",
+                "listr2": "~8.2.4",
+                "micromatch": "~4.0.8",
+                "pidtree": "~0.6.0",
+                "string-argv": "~0.3.2",
+                "yaml": "~2.5.0"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
@@ -3943,21 +4129,21 @@
             }
         },
         "node_modules/lint-staged/node_modules/commander": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-            "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+            "version": "12.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
             "engines": {
-                "node": ">=16"
+                "node": ">=18"
             }
         },
         "node_modules/lint-staged/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -3969,35 +4155,38 @@
             }
         },
         "node_modules/lint-staged/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
         "node_modules/lint-staged/node_modules/yaml": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
-            "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+            "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
             "dev": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/listr2": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-7.0.2.tgz",
-            "integrity": "sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==",
+            "version": "8.2.4",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.4.tgz",
+            "integrity": "sha512-opevsywziHd3zHCVQGAj8zu+Z3yHNkkoYhWIGnq54RrCVwLz0MozotJEDnKsIBLvkfLGN6BLOyAeRrYI0pKA4g==",
             "dev": true,
             "dependencies": {
-                "cli-truncate": "^3.1.0",
+                "cli-truncate": "^4.0.0",
                 "colorette": "^2.0.20",
                 "eventemitter3": "^5.0.1",
-                "log-update": "^5.0.1",
-                "rfdc": "^1.3.0",
-                "wrap-ansi": "^8.1.0"
+                "log-update": "^6.1.0",
+                "rfdc": "^1.4.1",
+                "wrap-ansi": "^9.0.0"
             },
             "engines": {
-                "node": ">=16.0.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/locate-path": {
@@ -4092,22 +4281,53 @@
             "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="
         },
         "node_modules/log-update": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-            "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+            "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
             "dev": true,
             "dependencies": {
-                "ansi-escapes": "^5.0.0",
-                "cli-cursor": "^4.0.0",
-                "slice-ansi": "^5.0.0",
-                "strip-ansi": "^7.0.1",
-                "wrap-ansi": "^8.0.1"
+                "ansi-escapes": "^7.0.0",
+                "cli-cursor": "^5.0.0",
+                "slice-ansi": "^7.1.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+            "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+            "dev": true,
+            "dependencies": {
+                "get-east-asian-width": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/log-update/node_modules/slice-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+            "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "is-fullwidth-code-point": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
         "node_modules/lru-cache": {
@@ -4142,9 +4362,12 @@
             "optional": true
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -4170,12 +4393,12 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -4224,6 +4447,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true,
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4255,12 +4490,12 @@
             }
         },
         "node_modules/mongodb": {
-            "version": "4.16.0",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
-            "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
+            "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
             "dependencies": {
                 "bson": "^4.7.2",
-                "mongodb-connection-string-url": "^2.5.4",
+                "mongodb-connection-string-url": "^2.6.0",
                 "socks": "^2.7.1"
             },
             "engines": {
@@ -4268,7 +4503,7 @@
             },
             "optionalDependencies": {
                 "@aws-sdk/credential-providers": "^3.186.0",
-                "saslprep": "^1.0.3"
+                "@mongodb-js/saslprep": "^1.1.0"
             }
         },
         "node_modules/mongodb-connection-string-url": {
@@ -4281,13 +4516,13 @@
             }
         },
         "node_modules/mongoose": {
-            "version": "6.11.6",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.6.tgz",
-            "integrity": "sha512-CuVbeJrEbnxkPUNNFvXJhjVyqa5Ip7lkz6EJX6g7Lb3aFMTJ+LHOlUrncxzC3r20dqasaVIiwcA6Y5qC8PWQ7w==",
+            "version": "6.13.2",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.2.tgz",
+            "integrity": "sha512-v99W8JS/9iz1f76A3q/G/E1e16p0QuUZdSFzE21kLMgg5LYtM//sqkFFwCDDqJSTQeCnGGDYWzGSCgpjsN1kAg==",
             "dependencies": {
                 "bson": "^4.7.2",
                 "kareem": "2.5.1",
-                "mongodb": "4.16.0",
+                "mongodb": "4.17.2",
                 "mpath": "0.9.0",
                 "mquery": "4.0.3",
                 "ms": "2.1.3",
@@ -4465,9 +4700,12 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -4632,9 +4870,9 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -4694,9 +4932,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-            "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -4761,11 +4999,11 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             },
             "engines": {
                 "node": ">=0.6"
@@ -4874,50 +5112,35 @@
             }
         },
         "node_modules/restore-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "dev": true,
             "dependencies": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/restore-cursor/node_modules/mimic-fn": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/restore-cursor/node_modules/onetime": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+            "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
             "dev": true,
             "dependencies": {
-                "mimic-fn": "^2.1.0"
+                "mimic-function": "^5.0.0"
             },
             "engines": {
-                "node": ">=6"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/restore-cursor/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "dev": true
         },
         "node_modules/reusify": {
             "version": "1.0.4",
@@ -4930,9 +5153,9 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true
         },
         "node_modules/rimraf": {
@@ -5105,18 +5328,6 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
-        "node_modules/saslprep": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-            "optional": true,
-            "dependencies": {
-                "sparse-bitfield": "^3.0.3"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/semver": {
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -5132,9 +5343,9 @@
             }
         },
         "node_modules/send": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -5167,23 +5378,47 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/serve-static": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
             "dependencies": {
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.18.0"
+                "send": "0.19.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/setprototypeof": {
@@ -5213,13 +5448,17 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5283,15 +5522,15 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "dependencies": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 10.0.0",
                 "npm": ">= 3.0.0"
             }
         },
@@ -5315,6 +5554,11 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "node_modules/statuses": {
             "version": "2.0.1",
@@ -5378,17 +5622,17 @@
             }
         },
         "node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
             "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5686,18 +5930,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/type-is": {
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -5773,9 +6005,13 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "optional": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
@@ -5833,17 +6069,17 @@
             }
         },
         "node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+            "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
             "dev": true,
             "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -5970,554 +6206,595 @@
                 "z-schema": "^5.0.1"
             }
         },
-        "@aws-crypto/crc32": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
-            "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
-            "optional": true,
-            "requires": {
-                "@aws-crypto/util": "^3.0.0",
-                "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "optional": true
-                }
-            }
-        },
-        "@aws-crypto/ie11-detection": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
-            "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
-            "optional": true,
-            "requires": {
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "optional": true
-                }
-            }
-        },
         "@aws-crypto/sha256-browser": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
-            "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
             "optional": true,
             "requires": {
-                "@aws-crypto/ie11-detection": "^3.0.0",
-                "@aws-crypto/sha256-js": "^3.0.0",
-                "@aws-crypto/supports-web-crypto": "^3.0.0",
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
                 "@aws-sdk/util-locate-window": "^3.0.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             },
             "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "optional": true
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "optional": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "optional": true,
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "optional": true,
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
                 }
             }
         },
         "@aws-crypto/sha256-js": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
-            "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
             "optional": true,
             "requires": {
-                "@aws-crypto/util": "^3.0.0",
+                "@aws-crypto/util": "^5.2.0",
                 "@aws-sdk/types": "^3.222.0",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "optional": true
-                }
+                "tslib": "^2.6.2"
             }
         },
         "@aws-crypto/supports-web-crypto": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
-            "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
             "optional": true,
             "requires": {
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "optional": true
-                }
+                "tslib": "^2.6.2"
             }
         },
         "@aws-crypto/util": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
-            "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
             "optional": true,
             "requires": {
                 "@aws-sdk/types": "^3.222.0",
-                "@aws-sdk/util-utf8-browser": "^3.0.0",
-                "tslib": "^1.11.1"
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
             },
             "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "optional": true
+                "@smithy/is-array-buffer": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+                    "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+                    "optional": true,
+                    "requires": {
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-buffer-from": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+                    "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+                    "optional": true,
+                    "requires": {
+                        "@smithy/is-array-buffer": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
+                },
+                "@smithy/util-utf8": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+                    "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+                    "optional": true,
+                    "requires": {
+                        "@smithy/util-buffer-from": "^2.2.0",
+                        "tslib": "^2.6.2"
+                    }
                 }
             }
         },
         "@aws-sdk/client-cognito-identity": {
-            "version": "3.397.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.397.0.tgz",
-            "integrity": "sha512-xQqjq7Rlg/10Pf5/u2ikn1UwJVTNPjHOvOo0rqwcAES9w8vGkkqCFYRK+cjpcxXXdTPOtN4KHbA5H31GzFVWPg==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.651.1.tgz",
+            "integrity": "sha512-FFTWI8uHXzsorQcAtPcvuXkH29sqFXVZa86UUvIrcd6kudakkUBeYDID2KYQm0FP/9uVH4xBBELHRC8PjEGmLw==",
             "optional": true,
             "requires": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/client-sts": "3.395.0",
-                "@aws-sdk/credential-provider-node": "3.395.0",
-                "@aws-sdk/middleware-host-header": "3.391.0",
-                "@aws-sdk/middleware-logger": "3.391.0",
-                "@aws-sdk/middleware-recursion-detection": "3.391.0",
-                "@aws-sdk/middleware-signing": "3.391.0",
-                "@aws-sdk/middleware-user-agent": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@aws-sdk/util-user-agent-browser": "3.391.0",
-                "@aws-sdk/util-user-agent-node": "3.391.0",
-                "@smithy/config-resolver": "^2.0.3",
-                "@smithy/fetch-http-handler": "^2.0.3",
-                "@smithy/hash-node": "^2.0.3",
-                "@smithy/invalid-dependency": "^2.0.3",
-                "@smithy/middleware-content-length": "^2.0.3",
-                "@smithy/middleware-endpoint": "^2.0.3",
-                "@smithy/middleware-retry": "^2.0.3",
-                "@smithy/middleware-serde": "^2.0.3",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/node-http-handler": "^2.0.3",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/smithy-client": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "@smithy/url-parser": "^2.0.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.0.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.3",
-                "@smithy/util-defaults-mode-node": "^2.0.3",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.651.1",
+                "@aws-sdk/client-sts": "3.651.1",
+                "@aws-sdk/core": "3.651.1",
+                "@aws-sdk/credential-provider-node": "3.651.1",
+                "@aws-sdk/middleware-host-header": "3.649.0",
+                "@aws-sdk/middleware-logger": "3.649.0",
+                "@aws-sdk/middleware-recursion-detection": "3.649.0",
+                "@aws-sdk/middleware-user-agent": "3.649.0",
+                "@aws-sdk/region-config-resolver": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@aws-sdk/util-user-agent-browser": "3.649.0",
+                "@aws-sdk/util-user-agent-node": "3.649.0",
+                "@smithy/config-resolver": "^3.0.6",
+                "@smithy/core": "^2.4.1",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/hash-node": "^3.0.4",
+                "@smithy/invalid-dependency": "^3.0.4",
+                "@smithy/middleware-content-length": "^3.0.6",
+                "@smithy/middleware-endpoint": "^3.1.1",
+                "@smithy/middleware-retry": "^3.0.16",
+                "@smithy/middleware-serde": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.4",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/url-parser": "^3.0.4",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.16",
+                "@smithy/util-defaults-mode-node": "^3.0.16",
+                "@smithy/util-endpoints": "^2.1.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "@smithy/util-retry": "^3.0.4",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/client-sso": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.395.0.tgz",
-            "integrity": "sha512-IEmqpZnflzFk6NTlkRpEXIcU2uBrTYl+pA5z4ZerbKclYWuxJ7MoLtLDNWgIn3mkNxvdroWgaPY1B2dkQlTe4g==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.651.1.tgz",
+            "integrity": "sha512-Fm8PoMgiBKmmKrY6QQUGj/WW6eIiQqC1I0AiVXfO+Sqkmxcg3qex+CZBAYrTuIDnvnc/89f9N4mdL8V9DRn03Q==",
             "optional": true,
             "requires": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.391.0",
-                "@aws-sdk/middleware-logger": "3.391.0",
-                "@aws-sdk/middleware-recursion-detection": "3.391.0",
-                "@aws-sdk/middleware-user-agent": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@aws-sdk/util-user-agent-browser": "3.391.0",
-                "@aws-sdk/util-user-agent-node": "3.391.0",
-                "@smithy/config-resolver": "^2.0.3",
-                "@smithy/fetch-http-handler": "^2.0.3",
-                "@smithy/hash-node": "^2.0.3",
-                "@smithy/invalid-dependency": "^2.0.3",
-                "@smithy/middleware-content-length": "^2.0.3",
-                "@smithy/middleware-endpoint": "^2.0.3",
-                "@smithy/middleware-retry": "^2.0.3",
-                "@smithy/middleware-serde": "^2.0.3",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/node-http-handler": "^2.0.3",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/smithy-client": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "@smithy/url-parser": "^2.0.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.0.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.3",
-                "@smithy/util-defaults-mode-node": "^2.0.3",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.651.1",
+                "@aws-sdk/middleware-host-header": "3.649.0",
+                "@aws-sdk/middleware-logger": "3.649.0",
+                "@aws-sdk/middleware-recursion-detection": "3.649.0",
+                "@aws-sdk/middleware-user-agent": "3.649.0",
+                "@aws-sdk/region-config-resolver": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@aws-sdk/util-user-agent-browser": "3.649.0",
+                "@aws-sdk/util-user-agent-node": "3.649.0",
+                "@smithy/config-resolver": "^3.0.6",
+                "@smithy/core": "^2.4.1",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/hash-node": "^3.0.4",
+                "@smithy/invalid-dependency": "^3.0.4",
+                "@smithy/middleware-content-length": "^3.0.6",
+                "@smithy/middleware-endpoint": "^3.1.1",
+                "@smithy/middleware-retry": "^3.0.16",
+                "@smithy/middleware-serde": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.4",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/url-parser": "^3.0.4",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.16",
+                "@smithy/util-defaults-mode-node": "^3.0.16",
+                "@smithy/util-endpoints": "^2.1.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "@smithy/util-retry": "^3.0.4",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/client-sso-oidc": {
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.651.1.tgz",
+            "integrity": "sha512-PKwAyTJW8pgaPIXm708haIZWBAwNycs25yNcD7OQ3NLcmgGxvrx6bSlhPEGcvwdTYwQMJsdx8ls+khlYbLqTvQ==",
+            "optional": true,
+            "requires": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.651.1",
+                "@aws-sdk/credential-provider-node": "3.651.1",
+                "@aws-sdk/middleware-host-header": "3.649.0",
+                "@aws-sdk/middleware-logger": "3.649.0",
+                "@aws-sdk/middleware-recursion-detection": "3.649.0",
+                "@aws-sdk/middleware-user-agent": "3.649.0",
+                "@aws-sdk/region-config-resolver": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@aws-sdk/util-user-agent-browser": "3.649.0",
+                "@aws-sdk/util-user-agent-node": "3.649.0",
+                "@smithy/config-resolver": "^3.0.6",
+                "@smithy/core": "^2.4.1",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/hash-node": "^3.0.4",
+                "@smithy/invalid-dependency": "^3.0.4",
+                "@smithy/middleware-content-length": "^3.0.6",
+                "@smithy/middleware-endpoint": "^3.1.1",
+                "@smithy/middleware-retry": "^3.0.16",
+                "@smithy/middleware-serde": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.4",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/url-parser": "^3.0.4",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.16",
+                "@smithy/util-defaults-mode-node": "^3.0.16",
+                "@smithy/util-endpoints": "^2.1.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "@smithy/util-retry": "^3.0.4",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/client-sts": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.395.0.tgz",
-            "integrity": "sha512-zWxZ+pjeP88uRN4k0Zzid6t/8Yhzg1Cv2LnrYX6kZzbS6AOTDho7fVGZgUl+cme33QZhtE8pXUvwGeJAptbhqg==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.651.1.tgz",
+            "integrity": "sha512-4X2RqLqeDuVLk+Omt4X+h+Fa978Wn+zek/AM4HSPi4C5XzRBEFLRRtOQUvkETvIjbEwTYQhm0LdgzcBH4bUqIg==",
             "optional": true,
             "requires": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/credential-provider-node": "3.395.0",
-                "@aws-sdk/middleware-host-header": "3.391.0",
-                "@aws-sdk/middleware-logger": "3.391.0",
-                "@aws-sdk/middleware-recursion-detection": "3.391.0",
-                "@aws-sdk/middleware-sdk-sts": "3.391.0",
-                "@aws-sdk/middleware-signing": "3.391.0",
-                "@aws-sdk/middleware-user-agent": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@aws-sdk/util-user-agent-browser": "3.391.0",
-                "@aws-sdk/util-user-agent-node": "3.391.0",
-                "@smithy/config-resolver": "^2.0.3",
-                "@smithy/fetch-http-handler": "^2.0.3",
-                "@smithy/hash-node": "^2.0.3",
-                "@smithy/invalid-dependency": "^2.0.3",
-                "@smithy/middleware-content-length": "^2.0.3",
-                "@smithy/middleware-endpoint": "^2.0.3",
-                "@smithy/middleware-retry": "^2.0.3",
-                "@smithy/middleware-serde": "^2.0.3",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/node-http-handler": "^2.0.3",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/smithy-client": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "@smithy/url-parser": "^2.0.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.0.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.3",
-                "@smithy/util-defaults-mode-node": "^2.0.3",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "fast-xml-parser": "4.2.5",
-                "tslib": "^2.5.0"
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/client-sso-oidc": "3.651.1",
+                "@aws-sdk/core": "3.651.1",
+                "@aws-sdk/credential-provider-node": "3.651.1",
+                "@aws-sdk/middleware-host-header": "3.649.0",
+                "@aws-sdk/middleware-logger": "3.649.0",
+                "@aws-sdk/middleware-recursion-detection": "3.649.0",
+                "@aws-sdk/middleware-user-agent": "3.649.0",
+                "@aws-sdk/region-config-resolver": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@aws-sdk/util-user-agent-browser": "3.649.0",
+                "@aws-sdk/util-user-agent-node": "3.649.0",
+                "@smithy/config-resolver": "^3.0.6",
+                "@smithy/core": "^2.4.1",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/hash-node": "^3.0.4",
+                "@smithy/invalid-dependency": "^3.0.4",
+                "@smithy/middleware-content-length": "^3.0.6",
+                "@smithy/middleware-endpoint": "^3.1.1",
+                "@smithy/middleware-retry": "^3.0.16",
+                "@smithy/middleware-serde": "^3.0.4",
+                "@smithy/middleware-stack": "^3.0.4",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/url-parser": "^3.0.4",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-body-length-node": "^3.0.0",
+                "@smithy/util-defaults-mode-browser": "^3.0.16",
+                "@smithy/util-defaults-mode-node": "^3.0.16",
+                "@smithy/util-endpoints": "^2.1.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "@smithy/util-retry": "^3.0.4",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/core": {
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.651.1.tgz",
+            "integrity": "sha512-eqOq3W39K+5QTP5GAXtmP2s9B7hhM2pVz8OPe5tqob8o1xQgkwdgHerf3FoshO9bs0LDxassU/fUSz1wlwqfqg==",
+            "optional": true,
+            "requires": {
+                "@smithy/core": "^2.4.1",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/signature-v4": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/credential-provider-cognito-identity": {
-            "version": "3.397.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.397.0.tgz",
-            "integrity": "sha512-Iv4V///p/iS5jXv5APFASBOOZ8oF8tC2y4G19PpdRWiZVv2A6fOAcguF0/HYr0CwAlvQT0HJA8+IxpMTu/bIQA==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.651.1.tgz",
+            "integrity": "sha512-tvrLvW+PxeJiw2cOc+LwJ0q86TGbXRul12jGswZWG7N71Ybr1s+e9//VeR8UwlxVCJOnm1FiWiWEd5WQmn25sQ==",
             "optional": true,
             "requires": {
-                "@aws-sdk/client-cognito-identity": "3.397.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/client-cognito-identity": "3.651.1",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/credential-provider-env": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.391.0.tgz",
-            "integrity": "sha512-mAzICedcg4bfL0mM5O6QTd9mQ331NLse1DMr6XL21ZZiLB48ej19L7AGV2xq5QwVbqKU3IVv1myRyhvpDM9jMg==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.649.0.tgz",
+            "integrity": "sha512-tViwzM1dauksA3fdRjsg0T8mcHklDa8EfveyiQKK6pUJopkqV6FQx+X5QNda0t/LrdEVlFZvwHNdXqOEfc83TA==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/credential-provider-http": {
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.649.0.tgz",
+            "integrity": "sha512-ODAJ+AJJq6ozbns6ejGbicpsQ0dyMOpnGlg0J9J0jITQ05DKQZ581hdB8APDOZ9N8FstShP6dLZflSj8jb5fNA==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/fetch-http-handler": "^3.2.5",
+                "@smithy/node-http-handler": "^3.2.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/smithy-client": "^3.3.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/util-stream": "^3.1.4",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/credential-provider-ini": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.395.0.tgz",
-            "integrity": "sha512-t7cWs+syJsSkj9NGdKyZ1t/+nYQyOec2nPjTtPWwKs8D7rvH3IMIgJwkvAGNzYaiIoIpXXx0wgCqys84TSEIYQ==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.651.1.tgz",
+            "integrity": "sha512-yOzPC3GbwLZ8IYzke4fy70ievmunnBUni/MOXFE8c9kAIV+/RMC7IWx14nAAZm0gAcY+UtCXvBVZprFqmctfzA==",
             "optional": true,
             "requires": {
-                "@aws-sdk/credential-provider-env": "3.391.0",
-                "@aws-sdk/credential-provider-process": "3.391.0",
-                "@aws-sdk/credential-provider-sso": "3.395.0",
-                "@aws-sdk/credential-provider-web-identity": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/credential-provider-env": "3.649.0",
+                "@aws-sdk/credential-provider-http": "3.649.0",
+                "@aws-sdk/credential-provider-process": "3.649.0",
+                "@aws-sdk/credential-provider-sso": "3.651.1",
+                "@aws-sdk/credential-provider-web-identity": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/credential-provider-imds": "^3.2.1",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/credential-provider-node": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.395.0.tgz",
-            "integrity": "sha512-qJawWTYf5L7Z1Is0sSJEYc4e96Qd0HWGqluO2h9qoUNrRREZ9RSxsDq+LGxVVAYLupYFcIFtiCnA/MoBBIWhzg==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.651.1.tgz",
+            "integrity": "sha512-QKA74Qs83FTUz3jS39kBuNbLAnm6cgDqomm7XS/BkYgtUq+1lI9WL97astNIuoYvumGIS58kuIa+I3ycOA4wgw==",
             "optional": true,
             "requires": {
-                "@aws-sdk/credential-provider-env": "3.391.0",
-                "@aws-sdk/credential-provider-ini": "3.395.0",
-                "@aws-sdk/credential-provider-process": "3.391.0",
-                "@aws-sdk/credential-provider-sso": "3.395.0",
-                "@aws-sdk/credential-provider-web-identity": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/credential-provider-env": "3.649.0",
+                "@aws-sdk/credential-provider-http": "3.649.0",
+                "@aws-sdk/credential-provider-ini": "3.651.1",
+                "@aws-sdk/credential-provider-process": "3.649.0",
+                "@aws-sdk/credential-provider-sso": "3.651.1",
+                "@aws-sdk/credential-provider-web-identity": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/credential-provider-imds": "^3.2.1",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/credential-provider-process": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.391.0.tgz",
-            "integrity": "sha512-KMlzPlBI+hBmXDo+EoFZdLgCVRkRa9B9iEE6x0+hQQ6g9bW6HI7cDRVdceR1ZoPasSaNAZ9QOXMTIBxTpn0sPQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.649.0.tgz",
+            "integrity": "sha512-6VYPQpEVpU+6DDS/gLoI40ppuNM5RPIEprK30qZZxnhTr5wyrGOeJ7J7wbbwPOZ5dKwta290BiJDU2ipV8Y9BQ==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/credential-provider-sso": {
-            "version": "3.395.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.395.0.tgz",
-            "integrity": "sha512-wAoHG9XqO0L8TvJv4cjwN/2XkYskp0cbnupKKTJm+D29MYcctKEtL0aYOHxaNN2ECAYxIFIQDdlo62GKb3nJ5Q==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.651.1.tgz",
+            "integrity": "sha512-7jeU+Jbn65aDaNjkjWDQcXwjNTzpYNKovkSSRmfVpP5WYiKerVS5mrfg3RiBeiArou5igCUtYcOKlRJiGRO47g==",
             "optional": true,
             "requires": {
-                "@aws-sdk/client-sso": "3.395.0",
-                "@aws-sdk/token-providers": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/client-sso": "3.651.1",
+                "@aws-sdk/token-providers": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/credential-provider-web-identity": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.391.0.tgz",
-            "integrity": "sha512-n0vYg82B8bc4rxKltVbVqclev7hx+elyS9pEnZs3YbnbWJq0qqsznXmDfLqd1TcWpa09PGXcah0nsRDolVThsA==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.649.0.tgz",
+            "integrity": "sha512-XVk3WsDa0g3kQFPmnCH/LaCtGY/0R2NDv7gscYZSXiBZcG/fixasglTprgWSp8zcA0t7tEIGu9suyjz8ZwhymQ==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/credential-providers": {
-            "version": "3.397.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.397.0.tgz",
-            "integrity": "sha512-X7GCXxr62h8mbnt+gZkk+CrfPPgkW/X7QgPIa7ZRHmQicUX7ZwPn5lVmUHTmHS6x+2F+VBigVPdVQ4QiUgC8bw==",
+            "version": "3.651.1",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.651.1.tgz",
+            "integrity": "sha512-Jv9WikitkarMbW+SaQETJ4/cNapRrsmS2GzU+axc9szqnY+fO6TFcFRB24AvdqCP1uNNasYsbCl/tryZSN/pNg==",
             "optional": true,
             "requires": {
-                "@aws-sdk/client-cognito-identity": "3.397.0",
-                "@aws-sdk/client-sso": "3.395.0",
-                "@aws-sdk/client-sts": "3.395.0",
-                "@aws-sdk/credential-provider-cognito-identity": "3.397.0",
-                "@aws-sdk/credential-provider-env": "3.391.0",
-                "@aws-sdk/credential-provider-ini": "3.395.0",
-                "@aws-sdk/credential-provider-node": "3.395.0",
-                "@aws-sdk/credential-provider-process": "3.391.0",
-                "@aws-sdk/credential-provider-sso": "3.395.0",
-                "@aws-sdk/credential-provider-web-identity": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/credential-provider-imds": "^2.0.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/client-cognito-identity": "3.651.1",
+                "@aws-sdk/client-sso": "3.651.1",
+                "@aws-sdk/client-sts": "3.651.1",
+                "@aws-sdk/credential-provider-cognito-identity": "3.651.1",
+                "@aws-sdk/credential-provider-env": "3.649.0",
+                "@aws-sdk/credential-provider-http": "3.649.0",
+                "@aws-sdk/credential-provider-ini": "3.651.1",
+                "@aws-sdk/credential-provider-node": "3.651.1",
+                "@aws-sdk/credential-provider-process": "3.649.0",
+                "@aws-sdk/credential-provider-sso": "3.651.1",
+                "@aws-sdk/credential-provider-web-identity": "3.649.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/credential-provider-imds": "^3.2.1",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/middleware-host-header": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.391.0.tgz",
-            "integrity": "sha512-+nyNr0rb2ixY7mU48nibr7L7gsw37y4oELhqgnNKhcjZDJ34imBwKIMFa64n21FdftmhcjR8IdSpzXE9xrkJ8g==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.649.0.tgz",
+            "integrity": "sha512-PjAe2FocbicHVgNNwdSZ05upxIO7AgTPFtQLpnIAmoyzMcgv/zNB5fBn3uAnQSAeEPPCD+4SYVEUD1hw1ZBvEg==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/middleware-logger": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.391.0.tgz",
-            "integrity": "sha512-KOwl5zo16b17JDhqILHBStccBQ2w35em7+/6vdkJdUII6OU8aVIFTlIQT9wOUvd4do6biIRBMZG3IK0Rg7mRDQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.649.0.tgz",
+            "integrity": "sha512-qdqRx6q7lYC6KL/NT9x3ShTL0TBuxdkCczGzHzY3AnOoYUjnCDH7Vlq867O6MAvb4EnGNECFzIgtkZkQ4FhY5w==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/middleware-recursion-detection": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.391.0.tgz",
-            "integrity": "sha512-hVR3z59G7pX4pjDQs9Ag1tMgbLeGXOzeAAaNP9fEtHSd3KBMAGQgN3K3b9WPjzE2W0EoloHRJMK4qxZErdde2g==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.649.0.tgz",
+            "integrity": "sha512-IPnO4wlmaLRf6IYmJW2i8gJ2+UPXX0hDRv1it7Qf8DpBW+lGyF2rnoN7NrFX0WIxdGOlJF1RcOr/HjXb2QeXfQ==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/middleware-sdk-sts": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.391.0.tgz",
-            "integrity": "sha512-6ZXI3Z4QU+TnT5PwKWloGmRHG81tWeI18/zxf9wWzrO2NhYFvITzEJH0vWLLiXdWtn/BYfLULXtDvkTaepbI5A==",
-            "optional": true,
-            "requires": {
-                "@aws-sdk/middleware-signing": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/middleware-signing": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.391.0.tgz",
-            "integrity": "sha512-2pAJJlZqaHc0d+cz2FTVrQmWi8ygKfqfczHUo/loCtOaMNtWXBHb/JsLEecs6cXdizy6gi3YsLz6VZYwY4Ssxw==",
-            "optional": true,
-            "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/signature-v4": "^2.0.0",
-                "@smithy/types": "^2.2.0",
-                "@smithy/util-middleware": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/middleware-user-agent": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.391.0.tgz",
-            "integrity": "sha512-LdK9uMNA14zqRw3B79Mhy7GX36qld/GYo93xuu+lr+AQ98leZEdc6GUbrtNDI3fP1Z8TMQcyHUKBml4/B+wXpQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.649.0.tgz",
+            "integrity": "sha512-q6sO10dnCXoxe9thobMJxekhJumzd1j6dxcE1+qJdYKHJr6yYgWbogJqrLCpWd30w0lEvnuAHK8lN2kWLdJxJw==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@aws-sdk/util-endpoints": "3.649.0",
+                "@smithy/protocol-http": "^4.1.1",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@aws-sdk/region-config-resolver": {
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.649.0.tgz",
+            "integrity": "sha512-xURBvdQXvRvca5Du8IlC5FyCj3pkw8Z75+373J3Wb+vyg8GjD14HfKk1Je1HCCQDyIE9VB/scYDcm9ri0ppePw==",
+            "optional": true,
+            "requires": {
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.4",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/token-providers": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.391.0.tgz",
-            "integrity": "sha512-kgfArsKLDJE71qQjfXiHiM5cZqgDHlMsqEx35+A65GmTWJaS1PGDqu3ZvVVU8E5mxnCCLw7vho21fsjvH6TBpg==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.649.0.tgz",
+            "integrity": "sha512-ZBqr+JuXI9RiN+4DSZykMx5gxpL8Dr3exIfFhxMiwAP3DQojwl0ub8ONjMuAjq9OvmX6n+jHZL6fBnNgnNFC8w==",
             "optional": true,
             "requires": {
-                "@aws-crypto/sha256-browser": "3.0.0",
-                "@aws-crypto/sha256-js": "3.0.0",
-                "@aws-sdk/middleware-host-header": "3.391.0",
-                "@aws-sdk/middleware-logger": "3.391.0",
-                "@aws-sdk/middleware-recursion-detection": "3.391.0",
-                "@aws-sdk/middleware-user-agent": "3.391.0",
-                "@aws-sdk/types": "3.391.0",
-                "@aws-sdk/util-endpoints": "3.391.0",
-                "@aws-sdk/util-user-agent-browser": "3.391.0",
-                "@aws-sdk/util-user-agent-node": "3.391.0",
-                "@smithy/config-resolver": "^2.0.3",
-                "@smithy/fetch-http-handler": "^2.0.3",
-                "@smithy/hash-node": "^2.0.3",
-                "@smithy/invalid-dependency": "^2.0.3",
-                "@smithy/middleware-content-length": "^2.0.3",
-                "@smithy/middleware-endpoint": "^2.0.3",
-                "@smithy/middleware-retry": "^2.0.3",
-                "@smithy/middleware-serde": "^2.0.3",
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/node-http-handler": "^2.0.3",
-                "@smithy/property-provider": "^2.0.0",
-                "@smithy/protocol-http": "^2.0.3",
-                "@smithy/shared-ini-file-loader": "^2.0.0",
-                "@smithy/smithy-client": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "@smithy/url-parser": "^2.0.3",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-body-length-browser": "^2.0.0",
-                "@smithy/util-body-length-node": "^2.0.0",
-                "@smithy/util-defaults-mode-browser": "^2.0.3",
-                "@smithy/util-defaults-mode-node": "^2.0.3",
-                "@smithy/util-retry": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/property-provider": "^3.1.4",
+                "@smithy/shared-ini-file-loader": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/types": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.391.0.tgz",
-            "integrity": "sha512-QpYVFKMOnzHz/JMj/b8wb18qxiT92U/5r5MmtRz2R3LOH6ooTO96k4ozXCrYr0qNed1PAnOj73rPrrH2wnCJKQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.649.0.tgz",
+            "integrity": "sha512-PuPw8RysbhJNlaD2d/PzOTf8sbf4Dsn2b7hwyGh7YVG3S75yTpxSAZxrnhKsz9fStgqFmnw/jUfV/G+uQAeTVw==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/util-endpoints": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.391.0.tgz",
-            "integrity": "sha512-zv4sYDTQhNxyLoekcE02/nk3xvoo6yCHDy1kDJk0MFxOKaqUB+CvZdQBR4YBLSDlD4o4DUBmdYgKT58FfbM8sQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.649.0.tgz",
+            "integrity": "sha512-bZI1Wc3R/KibdDVWFxX/N4AoJFG4VJ92Dp4WYmOrVD6VPkb8jPz7ZeiYc7YwPl8NoDjYyPneBV0lEoK/V8OKAA==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "tslib": "^2.5.0"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/types": "^3.4.0",
+                "@smithy/util-endpoints": "^2.1.0",
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/util-locate-window": {
-            "version": "3.310.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.310.0.tgz",
-            "integrity": "sha512-qo2t/vBTnoXpjKxlsC2e1gBrRm80M3bId27r0BRB2VniSSe7bL1mmzM+/HFtujm0iAxtPM+aLEflLJlJeDPg0w==",
+            "version": "3.568.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.568.0.tgz",
+            "integrity": "sha512-3nh4TINkXYr+H41QaPelCceEB2FXP3fxp93YZXB/kqJvX0U9j0N0Uk45gvsjmEPzG8XxkPEeLIfT2I1M7A6Lig==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/util-user-agent-browser": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.391.0.tgz",
-            "integrity": "sha512-6ipHOB1WdCBNeAMJauN7l2qNE0WLVaTNhkD290/ElXm1FHGTL8yw6lIDIjhIFO1bmbZxDiKApwDiG7ROhaJoxQ==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.649.0.tgz",
+            "integrity": "sha512-IY43r256LhKAvdEVQO/FPdUyVpcZS5EVxh/WHVdNzuN1bNLoUK2rIzuZqVA0EGguvCxoXVmQv9m50GvG7cGktg==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/types": "^2.2.0",
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/types": "^3.4.0",
                 "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@aws-sdk/util-user-agent-node": {
-            "version": "3.391.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.391.0.tgz",
-            "integrity": "sha512-PVvAK/Lf4BdB1eJIZtyFpGSslGQwKpYt9/hKs5NlR+qxBMXU9T0DnTqH4GiXZaazvXr7OUVWitIF2b7iKBMTow==",
+            "version": "3.649.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.649.0.tgz",
+            "integrity": "sha512-x5DiLpZDG/AJmCIBnE3Xhpwy35QIo3WqNiOpw6ExVs1NydbM/e90zFPSfhME0FM66D/WorigvluBxxwjxDm/GA==",
             "optional": true,
             "requires": {
-                "@aws-sdk/types": "3.391.0",
-                "@smithy/node-config-provider": "^2.0.3",
-                "@smithy/types": "^2.2.0",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@aws-sdk/util-utf8-browser": {
-            "version": "3.259.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-            "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-            "optional": true,
-            "requires": {
-                "tslib": "^2.3.1"
+                "@aws-sdk/types": "3.649.0",
+                "@smithy/node-config-provider": "^3.1.5",
+                "@smithy/types": "^3.4.0",
+                "tslib": "^2.6.2"
             }
         },
         "@eslint-community/eslint-utils": {
@@ -6620,6 +6897,15 @@
             "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
             "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
         },
+        "@mongodb-js/saslprep": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+            "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+            "optional": true,
+            "requires": {
+                "sparse-bitfield": "^3.0.3"
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6661,418 +6947,451 @@
             }
         },
         "@smithy/abort-controller": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.5.tgz",
-            "integrity": "sha512-byVZ2KWLMPYAZGKjRpniAzLcygJO4ruClZKdJTuB0eCB76ONFTdptBHlviHpAZXknRz7skYWPfcgO9v30A1SyA==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.4.tgz",
+            "integrity": "sha512-VupaALAQlXViW3/enTf/f5l5JZYSAxoJL7f0nanhNNKnww6DGCg1oYIuNP78KDugnkwthBO6iEcym16HhWV8RQ==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/config-resolver": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.5.tgz",
-            "integrity": "sha512-n0c2AXz+kjALY2FQr7Zy9zhYigXzboIh1AuUUVCqFBKFtdEvTwnwPXrTDoEehLiRTUHNL+4yzZ3s+D0kKYSLSg==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.8.tgz",
+            "integrity": "sha512-Tv1obAC18XOd2OnDAjSWmmthzx6Pdeh63FbLin8MlPiuJ2ATpKkq0NcNOJFr0dO+JmZXnwu8FQxKJ3TKJ3Hulw==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-config-provider": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-config-provider": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.6",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/core": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.4.3.tgz",
+            "integrity": "sha512-4LTusLqFMRVQUfC3RNuTg6IzYTeJNpydRdTKq7J5wdEyIRQSu3rGIa3s80mgG2hhe6WOZl9IqTSo1pgbn6EHhA==",
+            "optional": true,
+            "requires": {
+                "@smithy/middleware-endpoint": "^3.1.3",
+                "@smithy/middleware-retry": "^3.0.18",
+                "@smithy/middleware-serde": "^3.0.6",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/smithy-client": "^3.3.2",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-body-length-browser": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.6",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/credential-provider-imds": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.0.5.tgz",
-            "integrity": "sha512-KFcf/e0meFkQNyteJ65f1G19sgUEY1e5zL7hyAEUPz2SEfBmC9B37WyRq87G3MEEsvmAWwCRu7nFFYUKtR3svQ==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.3.tgz",
+            "integrity": "sha512-VoxMzSzdvkkjMJNE38yQgx4CfnmT+Z+5EUXkg4x7yag93eQkVQgZvN3XBSHC/ylfBbLbAtdu7flTCChX9I+mVg==",
             "optional": true,
             "requires": {
-                "@smithy/node-config-provider": "^2.0.5",
-                "@smithy/property-provider": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "@smithy/url-parser": "^2.0.5",
-                "tslib": "^2.5.0"
-            }
-        },
-        "@smithy/eventstream-codec": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.5.tgz",
-            "integrity": "sha512-iqR6OuOV3zbQK8uVs9o+9AxhVk8kW9NAxA71nugwUB+kTY9C35pUd0A5/m4PRT0Y0oIW7W4kgnSR3fdYXQjECw==",
-            "optional": true,
-            "requires": {
-                "@aws-crypto/crc32": "3.0.0",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/property-provider": "^3.1.6",
+                "@smithy/types": "^3.4.2",
+                "@smithy/url-parser": "^3.0.6",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/fetch-http-handler": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.0.5.tgz",
-            "integrity": "sha512-EzFoMowdBNy1VqtvkiXgPFEdosIAt4/4bgZ8uiDiUyfhmNXq/3bV+CagPFFBsgFOR/X2XK4zFZHRsoa7PNHVVg==",
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.7.tgz",
+            "integrity": "sha512-Ra6IPI1spYLO+t62/3jQbodjOwAbto9wlpJdHZwkycm0Kit+GVpzHW/NMmSgY4rK1bjJ4qLAmCnaBzePO5Nkkg==",
             "optional": true,
             "requires": {
-                "@smithy/protocol-http": "^2.0.5",
-                "@smithy/querystring-builder": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-base64": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/querystring-builder": "^3.0.6",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-base64": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/hash-node": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.5.tgz",
-            "integrity": "sha512-mk551hIywBITT+kXruRNXk7f8Fy7DTzBjZJSr/V6nolYKmUHIG3w5QU6nO9qPYEQGKc/yEPtkpdS28ndeG93lA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.6.tgz",
+            "integrity": "sha512-c/FHEdKK/7DU2z6ZE91L36ahyXWayR3B+FzELjnYq7wH5YqIseM24V+pWCS9kFn1Ln8OFGTf+pyYPiHZuX0s/Q==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/invalid-dependency": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.5.tgz",
-            "integrity": "sha512-0wEi+JT0hM+UUwrJVYbqjuGFhy5agY/zXyiN7BNAJ1XoCDjU5uaNSj8ekPWsXd/d4yM6NSe8UbPd8cOc1+3oBQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.6.tgz",
+            "integrity": "sha512-czM7Ioq3s8pIXht7oD+vmgy4Wfb4XavU/k/irO8NdXFFOx7YAlsCCcKOh/lJD1mJSYQqiR7NmpZ9JviryD/7AQ==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/is-array-buffer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-            "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+            "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/middleware-content-length": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.5.tgz",
-            "integrity": "sha512-E7VwV5H02fgZIUGRli4GevBCAPvkyEI/fgl9SU47nPPi3DAAX3nEtUb8xfGbXjOcJ5BdSUoWWZn42tEd/blOqA==",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.8.tgz",
+            "integrity": "sha512-VuyszlSO49WKh3H9/kIO2kf07VUwGV80QRiaDxUfP8P8UKlokz381ETJvwLhwuypBYhLymCYyNhB3fLAGBX2og==",
             "optional": true,
             "requires": {
-                "@smithy/protocol-http": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/middleware-endpoint": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.0.5.tgz",
-            "integrity": "sha512-tyzDuoNTbsMQCq5Xkc4QOt6e2GACUllQIV8SQ5fc59FtOIV9/vbf58/GxVjZm2o8+MMbdDBANjTDZe/ijZKfyA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.1.3.tgz",
+            "integrity": "sha512-KeM/OrK8MVFUsoJsmCN0MZMVPjKKLudn13xpgwIMpGTYpA8QZB2Xq5tJ+RE6iu3A6NhOI4VajDTwBsm8pwwrhg==",
             "optional": true,
             "requires": {
-                "@smithy/middleware-serde": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "@smithy/url-parser": "^2.0.5",
-                "@smithy/util-middleware": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/middleware-serde": "^3.0.6",
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/shared-ini-file-loader": "^3.1.7",
+                "@smithy/types": "^3.4.2",
+                "@smithy/url-parser": "^3.0.6",
+                "@smithy/util-middleware": "^3.0.6",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/middleware-retry": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.5.tgz",
-            "integrity": "sha512-ulIfbFyzQTVnJbLjUl1CTSi0etg6tej/ekwaLp0Gn8ybUkDkKYa+uB6CF/m2J5B6meRwyJlsryR+DjaOVyiicg==",
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.18.tgz",
+            "integrity": "sha512-YU1o/vYob6vlqZdd97MN8cSXRToknLXhFBL3r+c9CZcnxkO/rgNZ++CfgX2vsmnEKvlqdi26+SRtSzlVp5z6Mg==",
             "optional": true,
             "requires": {
-                "@smithy/protocol-http": "^2.0.5",
-                "@smithy/service-error-classification": "^2.0.0",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-middleware": "^2.0.0",
-                "@smithy/util-retry": "^2.0.0",
-                "tslib": "^2.5.0",
-                "uuid": "^8.3.2"
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/service-error-classification": "^3.0.6",
+                "@smithy/smithy-client": "^3.3.2",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-middleware": "^3.0.6",
+                "@smithy/util-retry": "^3.0.6",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
             }
         },
         "@smithy/middleware-serde": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.5.tgz",
-            "integrity": "sha512-in0AA5sous74dOfTGU9rMJBXJ0bDVNxwdXtEt5lh3FVd2sEyjhI+rqpLLRF1E4ixbw3RSEf80hfRpcPdjg4vvQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.6.tgz",
+            "integrity": "sha512-KKTUSl1MzOM0MAjGbudeaVNtIDo+PpekTBkCNwvfZlKndodrnvRo+00USatiyLOc0ujjO9UydMRu3O9dYML7ag==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/middleware-stack": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.0.tgz",
-            "integrity": "sha512-31XC1xNF65nlbc16yuh3wwTudmqs6qy4EseQUGF8A/p2m/5wdd/cnXJqpniy/XvXVwkHPz/GwV36HqzHtIKATQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.6.tgz",
+            "integrity": "sha512-2c0eSYhTQ8xQqHMcRxLMpadFbTXg6Zla5l0mwNftFCZMQmuhI7EbAJMx6R5eqfuV3YbJ3QGyS3d5uSmrHV8Khg==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/node-config-provider": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.0.5.tgz",
-            "integrity": "sha512-LRtjV9WkhONe2lVy+ipB/l1GX60ybzBmFyeRUoLUXWKdnZ3o81jsnbKzMK8hKq8eFSWPk+Lmyx6ZzCQabGeLxg==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.7.tgz",
+            "integrity": "sha512-g3mfnC3Oo8pOI0dYuPXLtdW1WGVb3bR2tkV21GNkm0ZvQjLTtamXAwCWt/FCb0HGvKt3gHHmF1XerG0ICfalOg==",
             "optional": true,
             "requires": {
-                "@smithy/property-provider": "^2.0.5",
-                "@smithy/shared-ini-file-loader": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/property-provider": "^3.1.6",
+                "@smithy/shared-ini-file-loader": "^3.1.7",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/node-http-handler": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.0.5.tgz",
-            "integrity": "sha512-lZm5DZf4b3V0saUw9WTC4/du887P6cy2fUyQgQQKRRV6OseButyD5yTzeMmXE53CaXJBMBsUvvIQ0hRVxIq56w==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.2.2.tgz",
+            "integrity": "sha512-42Cy4/oT2O+00aiG1iQ7Kd7rE6q8j7vI0gFfnMlUiATvyo8vefJkhb7O10qZY0jAqo5WZdUzfl9IV6wQ3iMBCg==",
             "optional": true,
             "requires": {
-                "@smithy/abort-controller": "^2.0.5",
-                "@smithy/protocol-http": "^2.0.5",
-                "@smithy/querystring-builder": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/abort-controller": "^3.1.4",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/querystring-builder": "^3.0.6",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/property-provider": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.5.tgz",
-            "integrity": "sha512-cAFSUhX6aiHcmpWfrCLKvwBtgN1F6A0N8qY/8yeSi0LRLmhGqsY1/YTxFE185MCVzYbqBGXVr9TBv4RUcIV4rA==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.6.tgz",
+            "integrity": "sha512-NK3y/T7Q/Bw+Z8vsVs9MYIQ5v7gOX7clyrXcwhhIBQhbPgRl6JDrZbusO9qWDhcEus75Tg+VCxtIRfo3H76fpw==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/protocol-http": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-2.0.5.tgz",
-            "integrity": "sha512-d2hhHj34mA2V86doiDfrsy2fNTnUOowGaf9hKb0hIPHqvcnShU4/OSc4Uf1FwHkAdYF3cFXTrj5VGUYbEuvMdw==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.3.tgz",
+            "integrity": "sha512-GcbMmOYpH9iRqtC05RbRnc/0FssxSTHlmaNhYBTgSgNCYpdR3Kt88u5GAZTBmouzv+Zlj/VRv92J9ruuDeJuEw==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/querystring-builder": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.5.tgz",
-            "integrity": "sha512-4DCX9krxLzATj+HdFPC3i8pb7XTAWzzKqSw8aTZMjXjtQY+vhe4azMAqIvbb6g7JKwIkmkRAjK6EXO3YWSnJVQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.6.tgz",
+            "integrity": "sha512-sQe08RunoObe+Usujn9+R2zrLuQERi3CWvRO3BvnoWSYUaIrLKuAIeY7cMeDax6xGyfIP3x/yFWbEKSXvOnvVg==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/querystring-parser": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.5.tgz",
-            "integrity": "sha512-C2stCULH0r54KBksv3AWcN8CLS3u9+WsEW8nBrvctrJ5rQTNa1waHkffpVaiKvcW2nP0aIMBPCobD/kYf/q9mA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.6.tgz",
+            "integrity": "sha512-UJKw4LlEkytzz2Wq+uIdHf6qOtFfee/o7ruH0jF5I6UAuU+19r9QV7nU3P/uI0l6+oElRHmG/5cBBcGJrD7Ozg==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/service-error-classification": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.0.tgz",
-            "integrity": "sha512-2z5Nafy1O0cTf69wKyNjGW/sNVMiqDnb4jgwfMG8ye8KnFJ5qmJpDccwIbJNhXIfbsxTg9SEec2oe1cexhMJvw==",
-            "optional": true
-        },
-        "@smithy/shared-ini-file-loader": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.0.5.tgz",
-            "integrity": "sha512-Mvtk6FwMtfbKRC4YuSsIqRYp9WTxsSUJVVo2djgyhcacKGMqicHDWSAmgy3sDrKv+G/G6xTZCPwm6pJARtdxVg==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.6.tgz",
+            "integrity": "sha512-53SpchU3+DUZrN7J6sBx9tBiCVGzsib2e4sc512Q7K9fpC5zkJKs6Z9s+qbMxSYrkEkle6hnMtrts7XNkMJJMg==",
             "optional": true,
             "requires": {
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2"
+            }
+        },
+        "@smithy/shared-ini-file-loader": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.7.tgz",
+            "integrity": "sha512-IA4K2qTJYXkF5OfVN4vsY1hfnUZjaslEE8Fsr/gGFza4TAC2A9NfnZuSY2srQIbt9bwtjHiAayrRVgKse4Q7fA==",
+            "optional": true,
+            "requires": {
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/signature-v4": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.5.tgz",
-            "integrity": "sha512-ABIzXmUDXK4n2c9cXjQLELgH2RdtABpYKT+U131e2I6RbCypFZmxIHmIBufJzU2kdMCQ3+thBGDWorAITFW04A==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.1.3.tgz",
+            "integrity": "sha512-YD2KYSCEEeFHcWZ1E3mLdAaHl8T/TANh6XwmocQ6nPcTdBfh4N5fusgnblnWDlnlU1/cUqEq3PiGi22GmT2Lkg==",
             "optional": true,
             "requires": {
-                "@smithy/eventstream-codec": "^2.0.5",
-                "@smithy/is-array-buffer": "^2.0.0",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-middleware": "^2.0.0",
-                "@smithy/util-uri-escape": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/is-array-buffer": "^3.0.0",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-middleware": "^3.0.6",
+                "@smithy/util-uri-escape": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/smithy-client": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.0.5.tgz",
-            "integrity": "sha512-kCTFr8wfOAWKDzGvfBElc6shHigWtHNhMQ1IbosjC4jOlayFyZMSs2PysKB+Ox/dhQ41KqOzgVjgiQ+PyWqHMQ==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.3.2.tgz",
+            "integrity": "sha512-RKDfhF2MTwXl7jan5d7QfS9eCC6XJbO3H+EZAvLQN8A5in4ib2Ml4zoeLo57w9QrqFekBPcsoC2hW3Ekw4vQ9Q==",
             "optional": true,
             "requires": {
-                "@smithy/middleware-stack": "^2.0.0",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-stream": "^2.0.5",
-                "tslib": "^2.5.0"
+                "@smithy/middleware-endpoint": "^3.1.3",
+                "@smithy/middleware-stack": "^3.0.6",
+                "@smithy/protocol-http": "^4.1.3",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-stream": "^3.1.6",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/types": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.2.2.tgz",
-            "integrity": "sha512-4PS0y1VxDnELGHGgBWlDksB2LJK8TG8lcvlWxIsgR+8vROI7Ms8h1P4FQUx+ftAX2QZv5g1CJCdhdRmQKyonyw==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.4.2.tgz",
+            "integrity": "sha512-tHiFcfcVedVBHpmHUEUHOCCih8iZbIAYn9NvPsNzaPm/237I3imdDdZoOC8c87H5HBAVEa06tTgb+OcSWV9g5w==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/url-parser": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.5.tgz",
-            "integrity": "sha512-OdMBvZhpckQSkugCXNJQCvqJ71wE7Ftxce92UOQLQ9pwF6hoS5PLL7wEfpnuEXtStzBqJYkzu1C1ZfjuFGOXAA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.6.tgz",
+            "integrity": "sha512-47Op/NU8Opt49KyGpHtVdnmmJMsp2hEwBdyjuFB9M2V5QVOwA7pBhhxKN5z6ztKGrMw76gd8MlbPuzzvaAncuQ==",
             "optional": true,
             "requires": {
-                "@smithy/querystring-parser": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/querystring-parser": "^3.0.6",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-base64": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.0.tgz",
-            "integrity": "sha512-Zb1E4xx+m5Lud8bbeYi5FkcMJMnn+1WUnJF3qD7rAdXpaL7UjkFQLdmW5fHadoKbdHpwH9vSR8EyTJFHJs++tA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+            "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
             "optional": true,
             "requires": {
-                "@smithy/util-buffer-from": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-body-length-browser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.0.tgz",
-            "integrity": "sha512-JdDuS4ircJt+FDnaQj88TzZY3+njZ6O+D3uakS32f2VNnDo3vyEuNdBOh/oFd8Df1zSZOuH1HEChk2AOYDezZg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+            "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-body-length-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-            "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+            "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-buffer-from": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-            "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+            "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
             "optional": true,
             "requires": {
-                "@smithy/is-array-buffer": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/is-array-buffer": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-config-provider": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.0.0.tgz",
-            "integrity": "sha512-xCQ6UapcIWKxXHEU4Mcs2s7LcFQRiU3XEluM2WcCjjBtQkUN71Tb+ydGmJFPxMUrW/GWMgQEEGipLym4XG0jZg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+            "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-defaults-mode-browser": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.5.tgz",
-            "integrity": "sha512-yciP6TPttLsj731aHTvekgyuCGXQrEAJibEwEWAh3kzaDsfGAVCuZSBlyvC2Dl3TZmHKCOQwHV8mIE7KQCTPuQ==",
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.18.tgz",
+            "integrity": "sha512-/eveCzU6Z6Yw8dlYQLA4rcK30XY0E4L3lD3QFHm59mzDaWYelrXE1rlynuT3J6qxv+5yNy3a1JuzhG5hk5hcmw==",
             "optional": true,
             "requires": {
-                "@smithy/property-provider": "^2.0.5",
-                "@smithy/types": "^2.2.2",
+                "@smithy/property-provider": "^3.1.6",
+                "@smithy/smithy-client": "^3.3.2",
+                "@smithy/types": "^3.4.2",
                 "bowser": "^2.11.0",
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-defaults-mode-node": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.5.tgz",
-            "integrity": "sha512-M07t99rWasXt+IaDZDyP3BkcoEm/mgIE1RIMASrE49LKSNxaVN7PVcgGc77+4uu2kzBAyqJKy79pgtezuknyjQ==",
+            "version": "3.0.18",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.18.tgz",
+            "integrity": "sha512-9cfzRjArtOFPlTYRREJk00suUxVXTgbrzVncOyMRTUeMKnecG/YentLF3cORa+R6mUOMSrMSnT18jos1PKqK6Q==",
             "optional": true,
             "requires": {
-                "@smithy/config-resolver": "^2.0.5",
-                "@smithy/credential-provider-imds": "^2.0.5",
-                "@smithy/node-config-provider": "^2.0.5",
-                "@smithy/property-provider": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "tslib": "^2.5.0"
+                "@smithy/config-resolver": "^3.0.8",
+                "@smithy/credential-provider-imds": "^3.2.3",
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/property-provider": "^3.1.6",
+                "@smithy/smithy-client": "^3.3.2",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
+            }
+        },
+        "@smithy/util-endpoints": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.2.tgz",
+            "integrity": "sha512-FEISzffb4H8DLzGq1g4MuDpcv6CIG15fXoQzDH9SjpRJv6h7J++1STFWWinilG0tQh9H1v2UKWG19Jjr2B16zQ==",
+            "optional": true,
+            "requires": {
+                "@smithy/node-config-provider": "^3.1.7",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-hex-encoding": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-            "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+            "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-middleware": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.0.tgz",
-            "integrity": "sha512-eCWX4ECuDHn1wuyyDdGdUWnT4OGyIzV0LN1xRttBFMPI9Ff/4heSHVxneyiMtOB//zpXWCha1/SWHJOZstG7kA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.6.tgz",
+            "integrity": "sha512-BxbX4aBhI1O9p87/xM+zWy0GzT3CEVcXFPBRDoHAM+pV0eSW156pR+PSYEz0DQHDMYDsYAflC2bQNz2uaDBUZQ==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-retry": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.0.tgz",
-            "integrity": "sha512-/dvJ8afrElasuiiIttRJeoS2sy8YXpksQwiM/TcepqdRVp7u4ejd9C4IQURHNjlfPUT7Y6lCDSa2zQJbdHhVTg==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.6.tgz",
+            "integrity": "sha512-BRZiuF7IwDntAbevqMco67an0Sr9oLQJqqRCsSPZZHYRnehS0LHDAkJk/pSmI7Z8c/1Vet294H7fY2fWUgB+Rg==",
             "optional": true,
             "requires": {
-                "@smithy/service-error-classification": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/service-error-classification": "^3.0.6",
+                "@smithy/types": "^3.4.2",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-stream": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.5.tgz",
-            "integrity": "sha512-ylx27GwI05xLpYQ4hDIfS15vm+wYjNN0Sc2P0FxuzgRe8v0BOLHppGIQ+Bezcynk8C9nUzsUue3TmtRhjut43g==",
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.1.6.tgz",
+            "integrity": "sha512-lQEUfTx1ht5CRdvIjdAN/gUL6vQt2wSARGGLaBHNe+iJSkRHlWzY+DOn0mFTmTgyU3jcI5n9DkT5gTzYuSOo6A==",
             "optional": true,
             "requires": {
-                "@smithy/fetch-http-handler": "^2.0.5",
-                "@smithy/node-http-handler": "^2.0.5",
-                "@smithy/types": "^2.2.2",
-                "@smithy/util-base64": "^2.0.0",
-                "@smithy/util-buffer-from": "^2.0.0",
-                "@smithy/util-hex-encoding": "^2.0.0",
-                "@smithy/util-utf8": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/fetch-http-handler": "^3.2.7",
+                "@smithy/node-http-handler": "^3.2.2",
+                "@smithy/types": "^3.4.2",
+                "@smithy/util-base64": "^3.0.0",
+                "@smithy/util-buffer-from": "^3.0.0",
+                "@smithy/util-hex-encoding": "^3.0.0",
+                "@smithy/util-utf8": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-uri-escape": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-            "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+            "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
             "optional": true,
             "requires": {
-                "tslib": "^2.5.0"
+                "tslib": "^2.6.2"
             }
         },
         "@smithy/util-utf8": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.0.tgz",
-            "integrity": "sha512-rctU1VkziY84n5OXe3bPNpKR001ZCME2JCaBBFgtiM2hfKbHFudc/BkMuPab8hRbLd0j3vbnBTTZ1igBf0wgiQ==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+            "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
             "optional": true,
             "requires": {
-                "@smithy/util-buffer-from": "^2.0.0",
-                "tslib": "^2.5.0"
+                "@smithy/util-buffer-from": "^3.0.0",
+                "tslib": "^2.6.2"
             }
         },
         "@types/async": {
@@ -7196,9 +7515,9 @@
             }
         },
         "@types/webidl-conversions": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-            "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+            "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
         },
         "@types/whatwg-url": {
             "version": "8.2.2",
@@ -7418,18 +7737,18 @@
             }
         },
         "ansi-escapes": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-            "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+            "integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
             "dev": true,
             "requires": {
-                "type-fest": "^1.0.2"
+                "environment": "^1.0.0"
             }
         },
         "ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+            "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
             "dev": true
         },
         "ansi-styles": {
@@ -7546,9 +7865,9 @@
             }
         },
         "body-parser": {
-            "version": "1.20.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
             "requires": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.5",
@@ -7558,7 +7877,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -7589,12 +7908,12 @@
             }
         },
         "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "requires": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             }
         },
         "bson": {
@@ -7652,12 +7971,15 @@
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
         },
         "call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
             }
         },
         "call-me-maybe": {
@@ -7678,22 +8000,22 @@
             "dev": true
         },
         "cli-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-            "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+            "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
             "dev": true,
             "requires": {
-                "restore-cursor": "^4.0.0"
+                "restore-cursor": "^5.0.0"
             }
         },
         "cli-truncate": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-            "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+            "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
             "dev": true,
             "requires": {
                 "slice-ansi": "^5.0.0",
-                "string-width": "^5.0.0"
+                "string-width": "^7.0.0"
             }
         },
         "color-convert": {
@@ -7823,9 +8145,9 @@
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
         },
         "cookie": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
         },
         "cookie-signature": {
             "version": "1.0.6",
@@ -7944,6 +8266,16 @@
                 "untildify": "^4.0.0"
             }
         },
+        "define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "requires": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            }
+        },
         "define-lazy-prop": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -7983,12 +8315,6 @@
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
         },
-        "eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true
-        },
         "ecdsa-sig-formatter": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -8003,15 +8329,15 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+            "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
             "dev": true
         },
         "encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
         },
         "end-of-stream": {
             "version": "1.4.4",
@@ -8020,6 +8346,25 @@
             "requires": {
                 "once": "^1.4.0"
             }
+        },
+        "environment": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+            "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+            "dev": true
+        },
+        "es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "requires": {
+                "get-intrinsic": "^1.2.4"
+            }
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
         },
         "escape-html": {
             "version": "1.0.3",
@@ -8246,36 +8591,36 @@
             }
         },
         "express": {
-            "version": "4.18.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-            "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+            "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
             "requires": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.1",
+                "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.5.0",
+                "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
+                "finalhandler": "1.3.1",
                 "fresh": "0.5.2",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
+                "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
+                "path-to-regexp": "0.1.10",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "type-is": "~1.6.18",
@@ -8283,36 +8628,6 @@
                 "vary": "~1.1.2"
             },
             "dependencies": {
-                "body-parser": {
-                    "version": "1.20.1",
-                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-                    "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-                    "requires": {
-                        "bytes": "3.1.2",
-                        "content-type": "~1.0.4",
-                        "debug": "2.6.9",
-                        "depd": "2.0.0",
-                        "destroy": "1.2.0",
-                        "http-errors": "2.0.0",
-                        "iconv-lite": "0.4.24",
-                        "on-finished": "2.4.1",
-                        "qs": "6.11.0",
-                        "raw-body": "2.5.1",
-                        "type-is": "~1.6.18",
-                        "unpipe": "1.0.0"
-                    }
-                },
-                "raw-body": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-                    "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-                    "requires": {
-                        "bytes": "3.1.2",
-                        "http-errors": "2.0.0",
-                        "iconv-lite": "0.4.24",
-                        "unpipe": "1.0.0"
-                    }
-                },
                 "safe-buffer": {
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8392,9 +8707,9 @@
             "dev": true
         },
         "fast-xml-parser": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
-            "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+            "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
             "optional": true,
             "requires": {
                 "strnum": "^1.0.5"
@@ -8419,21 +8734,21 @@
             }
         },
         "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
         },
         "finalhandler": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
@@ -8495,19 +8810,26 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
+        "get-east-asian-width": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz",
+            "integrity": "sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==",
+            "dev": true
         },
         "get-intrinsic": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3"
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
             }
         },
         "get-stream": {
@@ -8569,6 +8891,14 @@
                 "slash": "^3.0.0"
             }
         },
+        "gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "requires": {
+                "get-intrinsic": "^1.1.3"
+            }
+        },
         "graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -8580,29 +8910,37 @@
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
-        "has": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-            "requires": {
-                "function-bind": "^1.1.1"
-            }
-        },
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true
         },
+        "has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "requires": {
+                "es-define-property": "^1.0.0"
+            }
+        },
         "has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
         },
         "has-symbols": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        },
+        "hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "requires": {
+                "function-bind": "^1.1.2"
+            }
         },
         "http-errors": {
             "version": "2.0.0",
@@ -8620,12 +8958,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
             "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-            "dev": true
-        },
-        "husky": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-            "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
             "dev": true
         },
         "iconv-lite": {
@@ -8677,10 +9009,14 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
-        "ip": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+        "ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "requires": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            }
         },
         "ipaddr.js": {
             "version": "1.9.1",
@@ -8776,6 +9112,11 @@
             "requires": {
                 "argparse": "^2.0.1"
             }
+        },
+        "jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
         },
         "json-buffer": {
             "version": "3.0.1",
@@ -8895,70 +9236,70 @@
             }
         },
         "lilconfig": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
+            "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
             "dev": true
         },
         "lint-staged": {
-            "version": "15.0.2",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.0.2.tgz",
-            "integrity": "sha512-vnEy7pFTHyVuDmCAIFKR5QDO8XLVlPFQQyujQ/STOxe40ICWqJ6knS2wSJ/ffX/Lw0rz83luRDh+ET7toN+rOw==",
+            "version": "15.2.10",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
+            "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
             "dev": true,
             "requires": {
-                "chalk": "5.3.0",
-                "commander": "11.1.0",
-                "debug": "4.3.4",
-                "execa": "8.0.1",
-                "lilconfig": "2.1.0",
-                "listr2": "7.0.2",
-                "micromatch": "4.0.5",
-                "pidtree": "0.6.0",
-                "string-argv": "0.3.2",
-                "yaml": "2.3.3"
+                "chalk": "~5.3.0",
+                "commander": "~12.1.0",
+                "debug": "~4.3.6",
+                "execa": "~8.0.1",
+                "lilconfig": "~3.1.2",
+                "listr2": "~8.2.4",
+                "micromatch": "~4.0.8",
+                "pidtree": "~0.6.0",
+                "string-argv": "~0.3.2",
+                "yaml": "~2.5.0"
             },
             "dependencies": {
                 "commander": {
-                    "version": "11.1.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-                    "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+                    "version": "12.1.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+                    "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
                     "dev": true
                 },
                 "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "version": "4.3.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+                    "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.1.2"
+                        "ms": "^2.1.3"
                     }
                 },
                 "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
                     "dev": true
                 },
                 "yaml": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
-                    "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+                    "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
                     "dev": true
                 }
             }
         },
         "listr2": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-7.0.2.tgz",
-            "integrity": "sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==",
+            "version": "8.2.4",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-8.2.4.tgz",
+            "integrity": "sha512-opevsywziHd3zHCVQGAj8zu+Z3yHNkkoYhWIGnq54RrCVwLz0MozotJEDnKsIBLvkfLGN6BLOyAeRrYI0pKA4g==",
             "dev": true,
             "requires": {
-                "cli-truncate": "^3.1.0",
+                "cli-truncate": "^4.0.0",
                 "colorette": "^2.0.20",
                 "eventemitter3": "^5.0.1",
-                "log-update": "^5.0.1",
-                "rfdc": "^1.3.0",
-                "wrap-ansi": "^8.1.0"
+                "log-update": "^6.1.0",
+                "rfdc": "^1.4.1",
+                "wrap-ansi": "^9.0.0"
             }
         },
         "locate-path": {
@@ -9047,16 +9388,37 @@
             "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="
         },
         "log-update": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-            "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+            "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "^5.0.0",
-                "cli-cursor": "^4.0.0",
-                "slice-ansi": "^5.0.0",
-                "strip-ansi": "^7.0.1",
-                "wrap-ansi": "^8.0.1"
+                "ansi-escapes": "^7.0.0",
+                "cli-cursor": "^5.0.0",
+                "slice-ansi": "^7.1.0",
+                "strip-ansi": "^7.1.0",
+                "wrap-ansi": "^9.0.0"
+            },
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+                    "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+                    "dev": true,
+                    "requires": {
+                        "get-east-asian-width": "^1.0.0"
+                    }
+                },
+                "slice-ansi": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+                    "integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^6.2.1",
+                        "is-fullwidth-code-point": "^5.0.0"
+                    }
+                }
             }
         },
         "lru-cache": {
@@ -9085,9 +9447,9 @@
             "optional": true
         },
         "merge-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="
         },
         "merge-stream": {
             "version": "2.0.0",
@@ -9107,12 +9469,12 @@
             "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
         },
         "micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "requires": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             }
         },
@@ -9140,6 +9502,12 @@
             "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
             "dev": true
         },
+        "mimic-function": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+            "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+            "dev": true
+        },
         "minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -9159,14 +9527,14 @@
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "mongodb": {
-            "version": "4.16.0",
-            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.16.0.tgz",
-            "integrity": "sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==",
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
+            "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
             "requires": {
                 "@aws-sdk/credential-providers": "^3.186.0",
+                "@mongodb-js/saslprep": "^1.1.0",
                 "bson": "^4.7.2",
-                "mongodb-connection-string-url": "^2.5.4",
-                "saslprep": "^1.0.3",
+                "mongodb-connection-string-url": "^2.6.0",
                 "socks": "^2.7.1"
             }
         },
@@ -9180,13 +9548,13 @@
             }
         },
         "mongoose": {
-            "version": "6.11.6",
-            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.11.6.tgz",
-            "integrity": "sha512-CuVbeJrEbnxkPUNNFvXJhjVyqa5Ip7lkz6EJX6g7Lb3aFMTJ+LHOlUrncxzC3r20dqasaVIiwcA6Y5qC8PWQ7w==",
+            "version": "6.13.2",
+            "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.2.tgz",
+            "integrity": "sha512-v99W8JS/9iz1f76A3q/G/E1e16p0QuUZdSFzE21kLMgg5LYtM//sqkFFwCDDqJSTQeCnGGDYWzGSCgpjsN1kAg==",
             "requires": {
                 "bson": "^4.7.2",
                 "kareem": "2.5.1",
-                "mongodb": "4.16.0",
+                "mongodb": "4.17.2",
                 "mpath": "0.9.0",
                 "mquery": "4.0.3",
                 "ms": "2.1.3",
@@ -9320,9 +9688,9 @@
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
         },
         "object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+            "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g=="
         },
         "on-finished": {
             "version": "2.4.1",
@@ -9436,9 +9804,9 @@
             "dev": true
         },
         "path-to-regexp": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
         },
         "path-type": {
             "version": "4.0.0",
@@ -9480,9 +9848,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
-            "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true
         },
         "prettier-linter-helpers": {
@@ -9523,11 +9891,11 @@
             "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
         },
         "qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "requires": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             }
         },
         "queue-microtask": {
@@ -9603,35 +9971,23 @@
             "dev": true
         },
         "restore-cursor": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-            "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+            "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
             "dev": true,
             "requires": {
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2"
+                "onetime": "^7.0.0",
+                "signal-exit": "^4.1.0"
             },
             "dependencies": {
-                "mimic-fn": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-                    "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-                    "dev": true
-                },
                 "onetime": {
-                    "version": "5.1.2",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-                    "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+                    "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^2.1.0"
+                        "mimic-function": "^5.0.0"
                     }
-                },
-                "signal-exit": {
-                    "version": "3.0.7",
-                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-                    "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-                    "dev": true
                 }
             }
         },
@@ -9642,9 +9998,9 @@
             "dev": true
         },
         "rfdc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true
         },
         "rimraf": {
@@ -9757,15 +10113,6 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
-        "saslprep": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-            "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-            "optional": true,
-            "requires": {
-                "sparse-bitfield": "^3.0.3"
-            }
-        },
         "semver": {
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -9775,9 +10122,9 @@
             }
         },
         "send": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "requires": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -9794,6 +10141,11 @@
                 "statuses": "2.0.1"
             },
             "dependencies": {
+                "encodeurl": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+                    "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+                },
                 "ms": {
                     "version": "2.1.3",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9812,14 +10164,27 @@
             }
         },
         "serve-static": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
             "requires": {
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.18.0"
+                "send": "0.19.0"
+            }
+        },
+        "set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "requires": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
             }
         },
         "setprototypeof": {
@@ -9843,13 +10208,14 @@
             "dev": true
         },
         "side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "requires": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
             }
         },
         "sift": {
@@ -9890,11 +10256,11 @@
             "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
         },
         "socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "requires": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             }
         },
@@ -9915,6 +10281,11 @@
             "requires": {
                 "through": "2"
             }
+        },
+        "sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "statuses": {
             "version": "2.0.1",
@@ -9957,14 +10328,14 @@
             "dev": true
         },
         "string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
             "dev": true,
             "requires": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
             }
         },
         "strip-ansi": {
@@ -10180,12 +10551,6 @@
                 "prelude-ls": "^1.2.1"
             }
         },
-        "type-fest": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-            "dev": true
-        },
         "type-is": {
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -10242,9 +10607,9 @@
             "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
         },
         "uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
             "optional": true
         },
         "validator": {
@@ -10281,14 +10646,14 @@
             }
         },
         "wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+            "integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
             }
         },
         "wrappy": {

--- a/package.json
+++ b/package.json
@@ -49,9 +49,8 @@
         "eslint": "^8.52.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.1",
-        "husky": "^8.0.3",
         "lint-staged": "^15.0.2",
-        "prettier": "^3.0.3",
+        "prettier": "^3.3.3",
         "tsc-watch": "^6.0.4",
         "typescript": "^4.7.2"
     }

--- a/ui/src/Finalize.vue
+++ b/ui/src/Finalize.vue
@@ -42,7 +42,7 @@
                     @click="download(`bids/${ezbids.datasetDescription.Name}`)"
                     >Download BIDS</el-button
                 >
-                <el-button style="width: 250px" type="primary" @click="download(`finalized.json`)"
+                <el-button style="width: 250px" type="primary" @click="download(`ezBIDS_template.json`)"
                     >Download configuration/template</el-button
                 >
                 <p>Or send the dataset to other cloud resources.</p>


### PR DESCRIPTION
Changes/ additions:
- .env file allowing to define a custom/tmp folder
- automatic presort of DICOMs into subjects and sessions based on the acquisition date of the scans

Same start/running form the one defined in the ezBIDS documentations - using, `bash dev.sh`. 
To update, rebuild the containers in advance.